### PR TITLE
Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,29 +2,29 @@ import sbt._
 
 object Dependencies {
   
-  val scalatest                   = "org.scalatest"         %% "scalatest"                 % "3.2.11"
+  val scalatest                   = "org.scalatest"         %% "scalatest"                 % "3.2.12"
   val `cats-helper`               = "com.evolutiongaming"   %% "cats-helper"               % "3.0.3"
   val `executor-tools`            = "com.evolutiongaming"   %% "executor-tools"            % "1.0.3"
   val retry                       = "com.evolutiongaming"   %% "retry"                     % "3.0.1"
   val `akka-persistence-inmemory` = "com.github.dnvriend"   %% "akka-persistence-inmemory" % "2.5.15.2"
   val `kind-projector`            = "org.typelevel"          % "kind-projector"            % "0.13.2"
-  val pureconfig                  = "com.github.pureconfig" %% "pureconfig"                % "0.12.3"
-  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "1.0.1"
+  val pureconfig                  = "com.github.pureconfig" %% "pureconfig-generic"        % "0.17.1"
+  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "1.0.4"
 
   object Cats {
-    private val version = "2.7.0"
+    private val version = "2.8.0"
     val core   = "org.typelevel" %% "cats-core"   % version
     val kernel = "org.typelevel" %% "cats-kernel" % version
     val macros = "org.typelevel" %% "cats-macros" % version
   }
 
   object CatsEffect {
-    private val version = "3.3.7"
+    private val version = "3.3.12"
     val effect = "org.typelevel" %% "cats-effect" % version
   }
 
   object Akka {
-    private val version = "2.6.8"
+    private val version = "2.6.19"
     val actor               = "com.typesafe.akka" %% "akka-actor"             % version
     val testkit             = "com.typesafe.akka" %% "akka-testkit"           % version
     val stream              = "com.typesafe.akka" %% "akka-stream"            % version


### PR DESCRIPTION
- scalatest to 3.2.12 ([compare](https://github.com/scalatest/scalatest/compare/release-3.2.11...release-3.2.12))
- pureconfig-generic to 0.17.1 ([compare](https://github.com/pureconfig/pureconfig/compare/v0.12.3...v0.17.1))
- smetrics to 1.0.4 ([compare](https://github.com/evolution-gaming/smetrics/compare/v1.0.1...v1.0.4))
- cats to 2.8.0 ([compare](https://github.com/typelevel/cats/compare/v2.7.0...v2.8.0))
- cats-effect to 3.3.12 ([compare](https://github.com/typelevel/cats-effect/compare/v3.3.7...v3.3.12))
- akka to 2.6.19 ([compare](https://github.com/akka/akka/compare/v2.6.8...v2.6.19))