### PR TITLE
Fix Serially not handling many concurrent tasks

### DIFF
--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
@@ -57,7 +57,7 @@ private[akkaeffect] object Serially {
               (S.Active, start(s.value, t))
             case s: S.Active =>
               val task = (a: A) => for {
-                a <- s.task(a)
+                a <- Async[F].defer(s.task(a))
                 a <- t(a)
               } yield a
               (S.Active(task), Concurrent[F].unit)

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
@@ -56,10 +56,10 @@ private[akkaeffect] object Serially {
             case s: S.Idle   =>
               (S.Active, start(s.value, t))
             case s: S.Active =>
-              val task = (a: A) => for {
-                a <- Async[F].defer(s.task(a))
+              val task = (a: A) => Async[F].defer(for {
+                a <- s.task(a)
                 a <- t(a)
-              } yield a
+              } yield a)
               (S.Active(task), Concurrent[F].unit)
             case S.Active    =>
               (S.Active(t), Concurrent[F].unit)

--- a/actor/src/test/scala/com/evolutiongaming/akkaeffect/util/SeriallyTest.scala
+++ b/actor/src/test/scala/com/evolutiongaming/akkaeffect/util/SeriallyTest.scala
@@ -69,4 +69,17 @@ class SeriallyTest extends AsyncFunSuite with Matchers {
     } yield {}
     result.run()
   }
+
+  test("handles many concurrent tasks") {
+    var i = 0
+
+    val result = for {
+      serially <- IO { Serially[IO, Int](0) }
+      _ <- serially.apply(s => IO {
+        i = i + 1
+      }.as(s + 1)).parReplicateA(100000)
+      _ <- IO { i shouldEqual 100000 }
+    } yield ()
+    result.run()
+  }
 }


### PR DESCRIPTION
The issue with `Serially` is that it instantiates all chained functions when the first value is calculated. This leads to creating a lot of recursive function calls when the queue of waiting tasks is too big.  
This PR fixes that, deferring instantiation of these chained functions until they are needed. Please see a newly introduced test which reliably fails with the current version.