### PR TITLE
Fix Serially not handling many concurrent tasks (CE2)

### DIFF
--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
@@ -55,10 +55,10 @@ private[akkaeffect] object Serially {
           a <- ref.modify {
             case s: S.Idle   => (S.Active, start(s.value, t))
             case s: S.Active =>
-              val task = (a: A) => for {
-                a <- Concurrent[F].defer(s.task(a))
+              val task = (a: A) => Concurrent[F].defer(for {
+                a <- s.task(a)
                 a <- t(a)
-              } yield a
+              } yield a)
               (S.Active(task), Concurrent[F].unit)
             case S.Active    => (S.Active(t), Concurrent[F].unit)
           }

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Serially.scala
@@ -56,7 +56,7 @@ private[akkaeffect] object Serially {
             case s: S.Idle   => (S.Active, start(s.value, t))
             case s: S.Active =>
               val task = (a: A) => for {
-                a <- s.task(a)
+                a <- Concurrent[F].defer(s.task(a))
                 a <- t(a)
               } yield a
               (S.Active(task), Concurrent[F].unit)

--- a/actor/src/test/scala/com/evolutiongaming/akkaeffect/util/SeriallyTest.scala
+++ b/actor/src/test/scala/com/evolutiongaming/akkaeffect/util/SeriallyTest.scala
@@ -69,4 +69,21 @@ class SeriallyTest extends AsyncFunSuite with Matchers {
     } yield {}
     result.run()
   }
+
+  test("handles many concurrent tasks") {
+    var i = 0
+
+    val result = for {
+      serially <- IO {
+        Serially[IO, Int](0)
+      }
+      _ <- serially.apply(s => IO {
+        i = i + 1
+      }.as(s + 1)).parReplicateA(100000)
+      _ <- IO {
+        i shouldEqual 100000
+      }
+    } yield ()
+    result.run()
+  }
 }


### PR DESCRIPTION
The issue with `Serially` is that it instantiates all chained functions when the first value is calculated. This leads to creating a lot of recursive function calls when the queue of waiting tasks is too big.
This PR fixes that, deferring instantiation of these chained functions until they are needed. Please see a newly introduced test which reliably fails with the current version.

This is a backport of https://github.com/evolution-gaming/akka-effect/pull/175 to CE2-based branch.