### PR TITLE
Stabilise flaky tests

### DIFF
--- a/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala
+++ b/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala
@@ -111,6 +111,8 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
       _             <- journalKeeper.eventsSaved(1, ().pure[F])
       _             <- journalKeeper.eventsSaved(2, ().pure[F])
       _             <- journalKeeper.eventsSaved(3, ().pure[F])
+                    // Prevent race condition when 1st snapshot is written later than 2nd one is attempted and get discarded
+      _             <- Async[F].sleep(10.millis)
       _             <- journalKeeper.eventsSaved(4, deferred.complete(()).void)
       _             <- deferred.get
       actions       <- actions.get

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOfTest.scala
@@ -873,6 +873,7 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
         } yield {}
       }
       _              <- stopped.get
+      _              <- Async[F].sleep(10.millis) // Make sure all actions are performed first
       actions        <- actions.get
       _               = actions.reverse shouldEqual List(
         Action.Created(EventSourcedId("4"), akka.persistence.Recovery(), PluginIds.Empty),
@@ -934,6 +935,7 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
         } yield {}
       }
       _              <- stopped.get
+      _              <- Async[F].sleep(10.millis) // Make sure all actions are performed first
       actions        <- actions.get
       _               = actions.reverse shouldEqual List(
         Action.Created(EventSourcedId("5"), akka.persistence.Recovery(), PluginIds.Empty),


### PR DESCRIPTION
For `JournalKeeperTest`: there is a race condition that sometimes happens when:
1. Snapshot at the [2nd event](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala#L112) is in process of being saved, but metadata with [timestamp](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala#L492) is not generated yet
2. [4th event](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala#L114) arrives, and generates [timestamp](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala#L263) for snapshot [check](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala#L267), which is successful, but CAS of Ref is not yet performed
3. 1st snapshot is written, with timestamp later (1-2ms) than the one in the previous step, and the ref is [overwritten](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala#L208)
4. CAS from step 2 fails, repeats the loop, and this time [check](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala#L267) fails, due to potential timestamp being [older](https://github.com/evolution-gaming/akka-effect/blob/7c4b02b1df80608d5918efb2db5ea10f5fb0eb63/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala#L109) than the latest available snapshot metadata (from step 3), so 2nd snapshot is never saved

Interestingly enough, it only happens on CE3 branch; on CE2 the 4th event never gets to ref modification that fast.

As for `PersistentActorOfTest`, I didn't dig that deep, but I expect it to be a similar situation with [this](https://github.com/evolution-gaming/akka-effect/commit/0d5fb3537058a6679ceea74b522a7bfad8764d7b) fix.