### PR TITLE
Update Akka to 2.6.20

### DIFF
--- a/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocalTest.scala
+++ b/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocalTest.scala
@@ -16,6 +16,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.collection.immutable.IndexedSeq
 
 
 class ClusterShardingLocalTest extends AsyncFunSuite with ActorSuite with Matchers {

--- a/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocalTest.scala
+++ b/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocalTest.scala
@@ -46,13 +46,17 @@ class ClusterShardingLocalTest extends AsyncFunSuite with ActorSuite with Matche
 
     // Allocation strategy that doesn't use ActorSystem and Cluster extension (as opposed to Akka built-in strategies)
     val noopAllocationStrategy = new ShardAllocationStrategy {
-      override def allocateShard(requester: ActorRef,
-                                 shardId: ShardId,
-                                 currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]): Future[ActorRef] =
+      override def allocateShard(
+        requester: ActorRef,
+        shardId: ShardId,
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]]
+      ): Future[ActorRef] =
         Future.successful(requester)
 
-      override def rebalance(currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
-                             rebalanceInProgress: Set[ShardId]): Future[Set[ShardId]] =
+      override def rebalance(
+        currentShardAllocations: Map[ActorRef, IndexedSeq[ShardId]],
+        rebalanceInProgress: Set[ShardId]
+      ): Future[Set[ShardId]] =
         Future.successful(Set.empty)
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   }
 
   object Akka {
-    private val version = "2.6.8"
+    private val version = "2.6.20"
     val actor               = "com.typesafe.akka" %% "akka-actor"             % version
     val testkit             = "com.typesafe.akka" %% "akka-testkit"           % version
     val stream              = "com.typesafe.akka" %% "akka-stream"            % version


### PR DESCRIPTION
Test changes due to the fact that starting from `2.6.10` all akka built-in strategies require an `ActorSystem` with `Cluster` extension to function (polling cluster's member list), see https://github.com/akka/akka/pull/29548