### PR TITLE
Do NOT expose Engine state if it's Append already closed due to error

### DIFF
--- a/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/Engine.scala
+++ b/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/Engine.scala
@@ -314,13 +314,7 @@ object Engine {
       close <- CloseOnError.of[F]
     } yield new Engine[F, S, E] {
 
-      override def state: F[State[S]] = {
-        for {
-          error <- close.error
-          _     <- error.toLeft({}).liftTo[F]
-          state <- ref.get
-        } yield state.state
-      }
+      override def state: F[State[S]] = close(ref.get).map(_.state)
 
       override def apply[A](load: F[Validate[F, S, E, A]]): F[F[A]] = {
         for {


### PR DESCRIPTION
Motivation:

`Engine.state` can expose non-persisted state that should not be used by any other code. Existing implementation also cannot expose errors that prevent the state from been persisted and one outside the engine has no idea is the state persisted or speculative.

The change brings stronger guarantee of exposing actual state by raising exception that blocks the state from been persisted. 