### PR TITLE
Bump smetrics, cats-helper, deprecate legacy MeasureDuration usages

### DIFF
--- a/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterSharding.scala
@@ -14,7 +14,7 @@ import com.evolutiongaming.akkaeffect.{ActorRefOf, Ask}
 import com.evolutiongaming.catshelper.Blocking.implicits._
 import com.evolutiongaming.catshelper.CatsHelper._
 import com.evolutiongaming.catshelper._
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.smetrics
 
 import scala.concurrent.duration._
 
@@ -141,15 +141,33 @@ object ClusterSharding {
 
   implicit class ClusterShardingOps[F[_]](val self: ClusterSharding[F]) extends AnyVal {
 
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(implicit
+      F: BracketThrowable[F],
+      measureDuration: smetrics.MeasureDuration[F],
+      logOf: LogOf[F]
+    ): F[ClusterSharding[F]] = {
+      withLogging1(F, measureDuration.toCatsHelper, logOf)
+    }
+
+    def withLogging1(implicit
       F: BracketThrowable[F],
       measureDuration: MeasureDuration[F],
       logOf: LogOf[F]
     ): F[ClusterSharding[F]] = {
-      logOf(ClusterSharding.getClass).map { log => withLogging(log) }
+      logOf(ClusterSharding.getClass).map { log => withLogging1(log) }
     }
 
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: BracketThrowable[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): ClusterSharding[F] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: BracketThrowable[F],
       measureDuration: MeasureDuration[F]

--- a/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingTest.scala
+++ b/cluster-sharding/src/test/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingTest.scala
@@ -35,7 +35,7 @@ class ClusterShardingTest extends AsyncFunSuite with ActorSuite with Matchers {
       logOf                   <- LogOf.slf4j[IO].toResource
       log                     <- logOf(classOf[ClusterShardingTest]).toResource
       clusterSharding         <- ClusterSharding.of[IO](actorSystem)
-      clusterSharding         <- clusterSharding.withLogging(log).pure[Resource[IO, *]]
+      clusterSharding         <- clusterSharding.withLogging1(log).pure[Resource[IO, *]]
       clusterShardingSettings <- IO { ClusterShardingSettings(actorSystem) }.toResource
       actorRefOf               = ActorRefOf.fromActorRefFactory(actorSystem)
       probe                   <- Probe.of(actorRefOf)

--- a/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/Journaller.scala
+++ b/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/Journaller.scala
@@ -4,8 +4,8 @@ import cats.syntax.all._
 import cats.{Applicative, FlatMap, Functor, ~>}
 import com.evolutiongaming.akkaeffect.persistence
 import com.evolutiongaming.akkaeffect.persistence.SeqNr
-import com.evolutiongaming.catshelper.Log
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.catshelper.{Log, MeasureDuration}
+import com.evolutiongaming.smetrics
 
 
 trait Journaller[F[_]] {
@@ -35,8 +35,16 @@ object Journaller {
       (seqNr: SeqNr) => f(self.deleteTo(seqNr)).map(a => f(a))
     }
 
-
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: FlatMap[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): Journaller[F] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: FlatMap[F],
       measureDuration: MeasureDuration[F]

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Append.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Append.scala
@@ -8,8 +8,8 @@ import cats.{Applicative, FlatMap, Monad, ~>}
 import com.evolutiongaming.akkaeffect.util.AtomicRef
 import com.evolutiongaming.akkaeffect.{Act, Fail}
 import com.evolutiongaming.catshelper.CatsHelper._
-import com.evolutiongaming.catshelper.{Log, MonadThrowable, ToFuture}
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.catshelper.{Log, MeasureDuration, MonadThrowable, ToFuture}
+import com.evolutiongaming.smetrics
 
 import scala.collection.immutable.Queue
 
@@ -144,8 +144,16 @@ object Append {
 
     def narrow[B <: A]: Append[F, B] = events => self(events)
 
-
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: FlatMap[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): Append[F, A] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: FlatMap[F],
       measureDuration: MeasureDuration[F]

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/DeleteEventsTo.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/DeleteEventsTo.scala
@@ -5,8 +5,8 @@ import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import cats.{Applicative, FlatMap, ~>}
 import com.evolutiongaming.akkaeffect.Fail
-import com.evolutiongaming.catshelper.{FromFuture, Log, MonadThrowable}
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.catshelper.{FromFuture, Log, MeasureDuration, MonadThrowable}
+import com.evolutiongaming.smetrics
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -56,7 +56,16 @@ object DeleteEventsTo {
       }
     }
 
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: FlatMap[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): DeleteEventsTo[F] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: FlatMap[F],
       measureDuration: MeasureDuration[F]

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Journaller.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Journaller.scala
@@ -2,8 +2,8 @@ package com.evolutiongaming.akkaeffect.persistence
 
 import cats.{Applicative, FlatMap, Monad, ~>}
 import com.evolutiongaming.akkaeffect.Fail
-import com.evolutiongaming.catshelper.{Log, MonadThrowable}
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.catshelper.{Log, MeasureDuration, MonadThrowable}
+import com.evolutiongaming.smetrics
 
 
 /**
@@ -31,7 +31,7 @@ object Journaller {
   def empty[F[_]: Applicative, A]: Journaller[F, A] = {
     Journaller(Append.empty[F, A], DeleteEventsTo.empty[F])
   }
-  
+
 
   def apply[F[_], A](
     append: Append[F, A],
@@ -90,15 +90,23 @@ object Journaller {
       }
     }
 
-
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: FlatMap[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): Journaller[F, A] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: FlatMap[F],
       measureDuration: MeasureDuration[F]
     ): Journaller[F, A] = {
       Journaller(
-        self.append.withLogging(log),
-        self.deleteTo.withLogging(log))
+        self.append.withLogging1(log),
+        self.deleteTo.withLogging1(log))
     }
 
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Snapshotter.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Snapshotter.scala
@@ -1,14 +1,13 @@
 package com.evolutiongaming.akkaeffect.persistence
 
 import java.time.Instant
-
 import akka.persistence.{SnapshotSelectionCriteria, Snapshotter => _, _}
 import cats.effect.Sync
 import cats.syntax.all._
 import cats.{Applicative, FlatMap, ~>}
 import com.evolutiongaming.akkaeffect.Fail
-import com.evolutiongaming.catshelper.{FromFuture, Log, MonadThrowable}
-import com.evolutiongaming.smetrics.MeasureDuration
+import com.evolutiongaming.catshelper.{FromFuture, Log, MeasureDuration, MonadThrowable}
+import com.evolutiongaming.smetrics
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -95,8 +94,16 @@ object Snapshotter {
       }
     }
 
-
+    @deprecated("Use `withLogging1` instead", "0.4.0")
     def withLogging(
+      log: Log[F])(implicit
+      F: FlatMap[F],
+      measureDuration: smetrics.MeasureDuration[F]
+    ): Snapshotter[F, A] = {
+      withLogging1(log)(F, measureDuration.toCatsHelper)
+    }
+
+    def withLogging1(
       log: Log[F])(implicit
       F: FlatMap[F],
       measureDuration: MeasureDuration[F]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,13 @@ import sbt._
 object Dependencies {
   
   val scalatest                   = "org.scalatest"         %% "scalatest"                 % "3.2.15"
-  val `cats-helper`               = "com.evolutiongaming"   %% "cats-helper"               % "2.9.0"
+  val `cats-helper`               = "com.evolutiongaming"   %% "cats-helper"               % "2.12.0"
   val `executor-tools`            = "com.evolutiongaming"   %% "executor-tools"            % "1.0.4"
   val retry                       = "com.evolutiongaming"   %% "retry"                     % "2.1.1"
   val `akka-persistence-inmemory` = "com.github.dnvriend"   %% "akka-persistence-inmemory" % "2.5.15.2"
   val `kind-projector`            = "org.typelevel"          % "kind-projector"            % "0.13.2"
   val pureconfig                  = "com.github.pureconfig" %% "pureconfig"                % "0.17.3"
-  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "0.3.6"
+  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "0.4.2"
 
   object Cats {
     private val version = "2.9.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.3.1-SNAPSHOT"
+ThisBuild / version := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
Same as #241 , CE2 version