### PR TITLE
Interop with Akka Persistence plugins

### DIFF
--- a/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
@@ -1,0 +1,155 @@
+package akka.persistence
+
+import akka.actor.ActorSystem
+
+import cats.syntax.all._
+import cats.effect.{Async, Sync, Ref}
+
+import com.evolutiongaming.akkaeffect.ActorEffect
+import com.evolutiongaming.akkaeffect.persistence.{EventStore, EventSourcedId, SeqNr, Events}
+import com.evolutiongaming.catshelper.{FromFuture, ToTry}
+import com.evolutiongaming.sstream
+
+import scala.concurrent.duration._
+
+object EventStoreInterop {
+
+  def apply[F[_]: Async: FromFuture: ToTry, A](
+    system: ActorSystem,
+    timeout: FiniteDuration,
+    journalPluginId: String,
+    eventSourcedId: EventSourcedId
+  ): F[EventStore[F, A]] =
+    for {
+      appendedSeqNr <- Ref[F].of(SeqNr.Min)
+      journaller <- Sync[F].delay {
+        val actorRef = Persistence(system).journalFor(journalPluginId)
+        ActorEffect.fromActor(actorRef)
+      }
+    } yield new EventStore[F, A] {
+
+      import sstream.FoldWhile._
+
+      val persistenceId = eventSourcedId.value
+
+      override def from(seqNr: SeqNr): F[sstream.Stream[F, EventStore.Event[A]]] = {
+
+        type Buffer = Vector[EventStore.Event[A]]
+
+        def actor(buffer: Ref[F, Buffer]) =
+          LocalActorRef[F, Unit, SeqNr]({}, timeout) {
+
+            case (_, JournalProtocol.ReplayedMessage(persisted)) =>
+              if (persisted.deleted) ().asLeft[SeqNr].pure[F]
+              else {
+                val payload = persisted.payload.asInstanceOf[A]
+                val event   = EventStore.Event(payload, persisted.sequenceNr)
+                buffer.update(_ :+ event).as(().asLeft[SeqNr])
+              }
+
+            case (_, JournalProtocol.RecoverySuccess(seqNr)) =>
+              appendedSeqNr
+                .update(currentSeqNr => currentSeqNr max seqNr)
+                .as(seqNr.asRight[Unit])
+
+            case (_, JournalProtocol.ReplayMessagesFailure(error)) => error.raiseError[F, Either[Unit, SeqNr]]
+          }
+
+        for {
+          buffer <- Ref[F].of[Buffer](Vector.empty)
+          actor  <- actor(buffer)
+          request = JournalProtocol.ReplayMessages(seqNr, SeqNr.Max, Long.MaxValue, persistenceId, actor.ref)
+          _      <- journaller.tell(request)
+        } yield new sstream.Stream[F, EventStore.Event[A]] {
+
+          override def foldWhileM[L, R](l: L)(f: (L, EventStore.Event[A]) => F[Either[L, R]]): F[Either[L, R]] =
+            l.asLeft[R]
+              .tailRecM {
+
+                case Left(l) =>
+                  for {
+                    events <- buffer.getAndSet(Vector.empty)
+                    done   <- actor.get
+                    result <- events.foldWhileM(l)(f)
+                    result <- result match {
+
+                      case l: Left[L, R] =>
+                        done match {
+                          case Some(Right(_)) => l.asRight[Either[L, R]].pure[F]                      // no more events
+                          case Some(Left(er)) => er.raiseError[F, Either[Either[L, R], Either[L, R]]] // failure
+                          case None           => l.asLeft[Either[L, R]].pure[F]                       // expecting more events
+                        }
+
+                      // Right(...), cos user-defined function [[f]] desided to stop consuming stream thus wrapping in Right to break tailRecM loop
+                      case result => result.asRight[Either[L, R]].pure[F]
+
+                    }
+                  } yield result
+
+                case result => // cannot happened
+                  result.asRight[Either[L, R]].pure[F]
+              }
+
+        }
+
+      }
+
+      override def save(events: Events[A]): F[F[SeqNr]] = {
+
+        case class State(writes: Long, maxSeqNr: SeqNr)
+        val state = State(events.size, SeqNr.Min)
+        val actor = LocalActorRef[F, State, SeqNr](state, timeout) {
+
+          case (state, JournalProtocol.WriteMessagesSuccessful) => state.asLeft[SeqNr].pure[F]
+
+          case (state, JournalProtocol.WriteMessageSuccess(persistent, _)) =>
+            val seqNr = persistent.sequenceNr max state.maxSeqNr
+            val result =
+              if (state.writes == 1) seqNr.asRight[State]
+              else State(state.writes - 1, seqNr).asLeft[SeqNr]
+            result.pure[F]
+
+          case (_, JournalProtocol.WriteMessageRejected(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
+
+          case (_, JournalProtocol.WriteMessagesFailed(error, _)) => error.raiseError[F, Either[State, SeqNr]]
+
+          case (_, JournalProtocol.WriteMessageFailure(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
+        }
+
+        for {
+          messages <- appendedSeqNr.modify { seqNr =>
+            var _seqNr = seqNr
+            def nextSeqNr = {
+              _seqNr = _seqNr + 1
+              _seqNr
+            }
+            val messages = events.values.toList.map { events =>
+              val persistent = events.toList.map { event =>
+                PersistentRepr(event, persistenceId = persistenceId, sequenceNr = nextSeqNr)
+              }
+              AtomicWrite(persistent)
+            }
+            _seqNr -> messages
+          }
+          actor  <- actor
+          request = JournalProtocol.WriteMessages(messages, actor.ref, 0)
+          _      <- journaller.tell(request)
+        } yield actor.res
+      }
+
+      override def deleteTo(seqNr: SeqNr): F[F[Unit]] = {
+
+        val actor = LocalActorRef[F, Unit, Unit]({}, timeout) {
+          case (_, DeleteMessagesSuccess(_))    => ().asRight[Unit].pure[F]
+          case (_, DeleteMessagesFailure(e, _)) => e.raiseError[F, Either[Unit, Unit]]
+        }
+
+        for {
+          actor  <- actor
+          request = JournalProtocol.DeleteMessagesTo(persistenceId, seqNr, actor.ref)
+          _      <- journaller.tell(request)
+        } yield actor.res
+      }
+    }
+
+}

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -1,0 +1,134 @@
+package akka.persistence
+
+import akka.actor.{ActorRef, MinimalActorRef}
+import cats.effect.Temporal
+import cats.syntax.all._
+import com.evolutiongaming.catshelper.CatsHelper.OpsCatsHelper
+import com.evolutiongaming.catshelper.{SerialRef, ToTry}
+import scala.concurrent.duration.FiniteDuration
+import java.time.Instant
+import java.util.concurrent.TimeoutException
+import java.time.temporal.ChronoUnit
+
+/** Representation of actor capable of constructing result from multiple messages passed into the actor. Inspired by [[PromiseActorRef]] but
+  * result [[R]] is an aggregate from incomming messages rather that first message. Can be used only locally, does _not_ tolerate.
+  * [[ActorRef.provider]] and [[ActorRef.path]] functions.
+  * @tparam F
+  *   The effect type.
+  * @tparam R
+  *   The result type of the aggregate.
+  */
+private[persistence] trait LocalActorRef[F[_], R] {
+
+  def ref: ActorRef
+
+  /** Semantically blocking while aggregating result
+    */
+  def res: F[R]
+
+  /** Immidiately get currect state:
+    *
+    * \- [[None]] if aggregating not finished yet
+    *
+    * \- [[Some(Left(Throwable))]] if aggregation failed or timeout happened
+    *
+    * \- [[Some(Right(r))]] if aggregation completed successfully
+    */
+  def get: F[Option[Either[Throwable, R]]]
+}
+
+private[persistence] object LocalActorRef {
+
+  type M = Any
+
+  /** Create new [[LocalActorRef]]
+    *
+    * @param initial
+    *   The initial state of type [[S]].
+    * @param timeout
+    *   [[TimeoutException]] will be thrown if no incomming messages received within the timeout.
+    * @param receive
+    *   The aggregate function defining how to apply incomming message on state or produce final result: [[Left]] for continue aggregating
+    *   while [[Right]] for the result.
+    * @tparam F
+    *   The effect type.
+    * @tparam S
+    *   The aggregating state type.
+    * @tparam R
+    *   The final result type.
+    * @return
+    */
+  def apply[F[_]: Temporal: ToTry, S, R](initial: S, timeout: FiniteDuration)(
+    receive: PartialFunction[(S, M), F[Either[S, R]]]
+  ): F[LocalActorRef[F, R]] = {
+
+    val F = Temporal[F]
+
+    case class State(state: S, updated: Instant)
+
+    def timeoutException = new TimeoutException(s"no messages received during period of $timeout")
+
+    for {
+      now   <- F.realTimeInstant
+      state <- SerialRef.of[F, State](State(initial, now))
+      defer <- F.deferred[Either[Throwable, R]]
+      fiber <- F.start {
+        val f = for {
+          _ <- F.sleep(timeout)
+          s <- state.get
+          n <- F.realTimeInstant
+          c  = s.updated.plus(timeout.toNanos, ChronoUnit.NANOS).isBefore(n)
+          _ <- if (c) defer.complete(timeoutException.asLeft) else F.unit
+        } yield c
+
+        ().tailRecM { _ =>
+          f.ifF(().asRight, ().asLeft)
+        }
+      }
+    } yield new LocalActorRef[F, R] {
+
+      private def done(e: Either[Throwable, R]) =
+        for {
+          _ <- defer.complete(e)
+          _ <- fiber.cancel
+        } yield {}
+
+      override def ref: ActorRef = new MinimalActorRef {
+
+        override def provider = throw new UnsupportedOperationException()
+
+        override def path = throw new UnsupportedOperationException()
+
+        override def !(m: M)(implicit sender: ActorRef): Unit =
+          state
+            .update { s =>
+              if (receive.isDefinedAt(s.state -> m)) {
+
+                for {
+                  t <- Temporal[F].realTimeInstant
+                  r <- receive(s.state -> m)
+                  s <- r match {
+                    case Left(s)  => State(s, t).pure[F]
+                    case Right(r) => done(r.asRight).as(s)
+                  }
+                } yield s
+
+              } else {
+                s.pure[F]
+              }
+            }
+            .handleErrorWith { e =>
+              done(e.asLeft).void
+            }
+            .toTry
+            .get
+
+      }
+
+      override def res: F[R] = defer.get.flatMap(_.liftTo[F])
+
+      override def get: F[Option[Either[Throwable, R]]] = defer.tryGet
+    }
+  }
+
+}

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -1,0 +1,108 @@
+package akka.persistence
+
+import akka.actor.ActorSystem
+import akka.persistence.SnapshotSelectionCriteria
+
+import cats.syntax.all._
+import cats.effect.Sync
+
+import com.evolutiongaming.catshelper.FromFuture
+import com.evolutiongaming.akkaeffect.ActorEffect
+import com.evolutiongaming.akkaeffect.persistence.{SnapshotStore, EventSourcedId, SeqNr}
+
+import scala.concurrent.duration._
+import java.time.Instant
+
+object SnapshotStoreInterop {
+
+  def apply[F[_]: Sync: FromFuture, A](
+    system: ActorSystem,
+    timeout: FiniteDuration,
+    snapshotPluginId: String,
+    eventSourcedId: EventSourcedId
+  ): F[SnapshotStore[F, A]] =
+    Sync[F]
+      .delay {
+        val actorRef = Persistence(system).snapshotStoreFor(snapshotPluginId)
+        ActorEffect.fromActor(actorRef)
+      }
+      .map { snapshotter =>
+        new SnapshotStore[F, A] {
+
+          val persistenceId = eventSourcedId.value
+
+          override def latest: F[Option[SnapshotStore.Offer[A]]] = {
+            val criteria = SnapshotSelectionCriteria()
+            val request  = SnapshotProtocol.LoadSnapshot(persistenceId, criteria, Long.MaxValue)
+            snapshotter
+              .ask(request, timeout)
+              .flatMap { response =>
+                response.flatMap {
+
+                  case SnapshotProtocol.LoadSnapshotResult(snapshot, _) =>
+                    snapshot match {
+
+                      case Some(offer) =>
+                        val payload   = offer.snapshot.asInstanceOf[A]
+                        val timestamp = Instant.ofEpochMilli(offer.metadata.timestamp)
+                        val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp)
+                        SnapshotStore.Offer(payload, metadata).some.pure[F]
+
+                      case None => none[SnapshotStore.Offer[A]].pure[F]
+                    }
+
+                  case SnapshotProtocol.LoadSnapshotFailed(err) =>
+                    err.raiseError[F, Option[SnapshotStore.Offer[A]]]
+                }
+              }
+          }
+
+          override def save(seqNr: SeqNr, snapshot: A): F[F[Instant]] = {
+            val metadata = SnapshotMetadata(persistenceId, seqNr)
+            val request  = SnapshotProtocol.SaveSnapshot(metadata, snapshot)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case SaveSnapshotSuccess(metadata) => Instant.ofEpochMilli(metadata.timestamp).pure[F]
+                  case SaveSnapshotFailure(_, err)   => err.raiseError[F, Instant]
+                }
+
+              }
+          }
+
+          override def delete(seqNr: SeqNr): F[F[Unit]] = {
+            val metadata = SnapshotMetadata(persistenceId, seqNr)
+            val request  = SnapshotProtocol.DeleteSnapshot(metadata)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case DeleteSnapshotSuccess(_)      => ().pure[F]
+                  case DeleteSnapshotFailure(_, err) => err.raiseError[F, Unit]
+                }
+              }
+          }
+
+          override def delete(criteria: SnapshotStore.Criteria): F[F[Unit]] = {
+            val query = SnapshotSelectionCriteria(
+              maxSequenceNr = criteria.maxSequenceNr,
+              maxTimestamp = criteria.maxTimestamp,
+              minSequenceNr = criteria.minSequenceNr,
+              minTimestamp = criteria.minTimestamp
+            )
+            val request = SnapshotProtocol.DeleteSnapshots(persistenceId, query)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case DeleteSnapshotsSuccess(_)      => ().pure[F]
+                  case DeleteSnapshotsFailure(_, err) => err.raiseError[F, Unit]
+                }
+              }
+          }
+
+        }
+      }
+
+}

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -1,0 +1,198 @@
+package akka.persistence
+
+import akka.persistence.journal.AsyncWriteJournal
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+
+import com.evolutiongaming.akkaeffect.persistence.EventSourcedId
+import com.evolutiongaming.akkaeffect.persistence.Events
+import com.evolutiongaming.akkaeffect.persistence.SeqNr
+import com.evolutiongaming.akkaeffect.persistence.EventStore
+import com.evolutiongaming.akkaeffect.testkit.TestActorSystem
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+class EventStoreInteropTest extends AnyFunSuite with Matchers {
+
+  val emptyPluginId = ""
+
+  test("journal: replay (nothing), save, replay, delete, replay") {
+
+    val persistenceId = EventSourcedId("#11")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List.empty[EventStore.Event[String]]
+          seqNr  <- store.save(Events.of("first", "second")).flatten
+          _       = seqNr shouldEqual 2L
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List(EventStore.Event("first", 1L), EventStore.Event("second", 2L))
+          _      <- store.deleteTo(1L).flatten
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List(EventStore.Event("second", 2L))
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail loading events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#11")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          error  <- events.toList.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[List[EventStore.Event[String]]]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail persisting events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#12")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          seqNr <- store.save(Events.of[String]("first", "second"))
+          error <- seqNr.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[SeqNr]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail deleting events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#13")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.deleteTo(SeqNr.Max)
+          error    <- deleting.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[Unit]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout on loading events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#14")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          error  <- events.toList.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout persisting events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#15")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          seqNr <- store.save(Events.of[String]("first", "second"))
+          error <- seqNr.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout deleting events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#16")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.deleteTo(SeqNr.Max)
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+}
+
+object FailingJournal {
+  val exception = new RuntimeException("test exception")
+}
+
+class FailingJournal extends AsyncWriteJournal {
+
+  override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
+    recoveryCallback: PersistentRepr => Unit
+  ): Future[Unit] = Future.failed(FailingJournal.exception)
+
+  override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
+    Future.failed(FailingJournal.exception)
+
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.failed(FailingJournal.exception)
+
+  override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = Future.failed(FailingJournal.exception)
+
+}
+
+class InfiniteJournal extends AsyncWriteJournal {
+
+  override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
+    recoveryCallback: PersistentRepr => Unit
+  ): Future[Unit] = Future.never
+
+  override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = Future.never
+
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.never
+
+  override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = Future.never
+
+}

--- a/persistence/src/test/scala/akka/persistence/LocalActorRefTest.scala
+++ b/persistence/src/test/scala/akka/persistence/LocalActorRefTest.scala
@@ -1,0 +1,101 @@
+package akka.persistence
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
+class LocalActorRefTest extends AnyFunSuite with Matchers {
+
+  val poison  = 100500
+  val timeout = 1.second
+
+  def of = LocalActorRef[IO, Int, Int](0, timeout) {
+    case (s, `poison`) => IO(s.asRight)
+    case (s, m: Int)   => IO((s + m).asLeft)
+  }
+
+  test("LocalActorRef can handle messages and produce result") {
+    val io = for {
+      r <- of
+      n <- r.get
+      _  = n shouldEqual none
+      _ <- IO(r.ref ! 3)
+      _ <- IO(r.ref ! 4)
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual 7
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef.res semantically blocks until result produced") {
+    val io = for {
+      d  <- IO.deferred[Unit]
+      r  <- of
+      f   = r.res >> d.complete {}
+      f  <- f.start
+      d0 <- d.tryGet
+      _   = d0 shouldEqual none
+      _  <- IO(r.ref ! poison)
+      _  <- f.join
+      d1 <- d.tryGet
+      _   = d1 shouldEqual {}.some
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef should handle concurrent ! operations") {
+    val io = for {
+      r <- of
+      l  = List.range(0, 100)
+      _ <- l.parTraverse(i => IO(r.ref ! i))
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual l.sum
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test(s"LocalActorRef should timeout aftet $timeout") {
+    val io = for {
+      r <- of
+      _ <- IO.sleep(timeout * 2)
+      e <- r.get
+      _ = e match {
+        case Some(Left(_: TimeoutException)) => succeed
+        case other                           => fail(s"unexpected result $other")
+      }
+      e <- r.res.attempt
+      _ = e match {
+        case Left(_: TimeoutException) => succeed
+        case other                     => fail(s"unexpected result $other")
+      }
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef should not timeout while receiving messages within timeout span") {
+    val io = for {
+      r <- of
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! 2)
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! 3)
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual 5
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+}

--- a/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
@@ -1,0 +1,253 @@
+package akka.persistence
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import cats.syntax.all._
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import com.evolutiongaming.akkaeffect.persistence.{EventSourcedId, SeqNr, SnapshotStore}
+import com.evolutiongaming.akkaeffect.testkit.TestActorSystem
+
+import scala.util.Random
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import akka.pattern.AskTimeoutException
+import java.time.Instant
+
+class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
+
+  val emptyPluginId = ""
+
+  test("snapshot: load, save and load again") {
+
+    val persistenceId = EventSourcedId("#1")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          snapshot <- store.latest
+          _         = snapshot shouldEqual none
+          _        <- store.save(SeqNr.Min, payload).flatten
+          snapshot <- store.latest
+          _         = snapshot.get.snapshot should equal(payload)
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: save, load, delete and load again") {
+
+    val persistenceId = EventSourcedId("#2")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          _        <- store.save(SeqNr.Min, payload).flatten
+          snapshot <- store.latest
+          _         = snapshot.get.snapshot should equal(payload)
+          _        <- store.delete(SeqNr.Min).flatten
+          snapshot <- store.latest
+          _         = snapshot shouldEqual none
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail load snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#3")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          error <- store.latest.attempt
+          _      = error shouldEqual FailingSnapshotter.exception.asLeft[List[SnapshotStore.Offer[String]]]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail save snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#4")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          saving <- store.save(SeqNr.Min, payload)
+          error  <- saving.attempt
+          _       = error shouldEqual FailingSnapshotter.exception.asLeft[Instant]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail delete snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#5")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SeqNr.Min)
+          error    <- deleting.attempt
+          _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail delete snapshot by criteria") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#6")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SnapshotStore.Criteria())
+          error    <- deleting.attempt
+          _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout loading snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#7")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use(system =>
+        for {
+          store <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          error <- store.latest.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      )
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout saving snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#8")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          saving <- store.save(SeqNr.Min, payload)
+          error  <- saving.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout deleting snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#9")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SeqNr.Min)
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout deleting snapshot by criteria") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#10")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SnapshotStore.Criteria())
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+}
+
+object FailingSnapshotter {
+
+  val exception = new RuntimeException("test exception")
+
+}
+
+class FailingSnapshotter extends akka.persistence.snapshot.SnapshotStore {
+
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] =
+    Future.failed(FailingSnapshotter.exception)
+
+  override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = Future.failed(FailingSnapshotter.exception)
+
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = Future.failed(FailingSnapshotter.exception)
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] =
+    Future.failed(FailingSnapshotter.exception)
+
+}
+
+class InfiniteSnapshotter extends akka.persistence.snapshot.SnapshotStore {
+
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = Future.never
+
+  override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = Future.never
+
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = Future.never
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = Future.never
+
+}


### PR DESCRIPTION
This PR is second in the sequence of depended PRs:
1. [New persistence api module](https://github.com/evolution-gaming/akka-effect/pull/273)
2. [Interop w/ Akka Persistence plugins](https://github.com/evolution-gaming/akka-effect/pull/274), this one
3. [New persistent actor impl](https://github.com/evolution-gaming/akka-effect/pull/275)

The PR contains interoperability between Akka Persistence plugins and persistence API defined in `persistence-api` module, making all set of available Akka Persistence plugins valid implementations of new persistence API introduced in previous PR. 

Akka Persistence plugins can be accessed as actors via restricted to `akka.persistence` package API thus interop implementation located in the same package. Snapshot plugin interop implemented using "ask pattern" due to its simplicity - each operation represented by one command to the plugin actor and one reply command. Journal plugin interop implemented using `LocalActorRef`, inspired by "ask pattern" but supporting multi-command reply.

The reasoning behind `LocalActorRef` is in avoiding overhead of having new actor (per request) and avoiding state management in one long-leaving actor (that can handle all those commands to snaphotter or journaller actors). Actors are pretty cheap but not fully free and IMO creating new one each time on persisting events will be too much. On other hand managing concurrent requests within one long-living actor (lifespan should be equal to main actor) also better to be avoided cos concurrent requests must be supported by the persistent plugin anyway and having same logic twice not perfect solution. 

As an alternative I'm proposing using `LocalActorRef` - lightweight `ActorRef` implementation allows aggregating result from multiple responses. Its functionality is limited and should not be used outside of `akka-effect` thus it marked as `private[akka.persistence]`    