### PR TITLE
Persistent actor implementation & interop with Akka snapshot/journal plugins   

### DIFF
--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
@@ -7,14 +7,16 @@ trait EventStore[F[_], A] extends EventStore.Read[F, A] with EventStore.Write[F,
 object EventStore {
 
   trait Read[F[_], A] {
-    def from(seqNr: SeqNr): F[sstream.Stream[F, Event[A]]]
+    def events(fromSeqNr: SeqNr): F[sstream.Stream[F, Persisted[A]]]
   }
 
   trait Write[F[_], A] {
-    def save(events: Events[A]): F[F[SeqNr]]
+    def save(events: Events[Event[A]]): F[F[SeqNr]]
     def deleteTo(seqNr: SeqNr): F[F[Unit]]
   }
 
-  final case class Event[A](event: A, seqNr: SeqNr)
+  sealed trait Persisted[+A]
+  final case class HighestSeqNr(seqNr: SeqNr)       extends Persisted[Nothing]
+  final case class Event[A](event: A, seqNr: SeqNr) extends Persisted[A]
 
 }

--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
@@ -2,21 +2,66 @@ package com.evolutiongaming.akkaeffect.persistence
 
 import com.evolutiongaming.sstream
 
+/** Persistent event store API used in event-sourced actors [[EventSourcedActorOf]]. The API consists of two parts: [[EventStore.Read]] and
+  * [[EventStore.Write]] that represents reading (actually streaming) and persisting events.
+  */
 trait EventStore[F[_], A] extends EventStore.Read[F, A] with EventStore.Write[F, A]
 
 object EventStore {
 
   trait Read[F[_], A] {
+
+    /** Request stream of events starting from [[SeqNr]].
+      *
+      * @param fromSeqNr
+      *   sequence number of first event in stream if any
+      * @return
+      *   lazy event stream of type [[sstream.Stream]]
+      */
     def events(fromSeqNr: SeqNr): F[sstream.Stream[F, Persisted[A]]]
   }
 
   trait Write[F[_], A] {
+
+    /** Persist events in batches. Outer [[NonEmptyList]] of [[Events#values]] can be used for batching while inner [[NonEmptyList]] must be
+      * persisted atomically.
+      *
+      * @param events
+      *   events to be persisted
+      * @return
+      *   outer F represents request send while inner F represents request complete
+      */
     def save(events: Events[Event[A]]): F[F[SeqNr]]
+
+    /** Delete events with sequence number up to [[SeqNr]] inclusive.
+      *
+      * @param seqNr
+      *   sequence number up to which events will be deleted
+      * @return
+      *   outer F represents request send while inner F represents request complete
+      */
     def deleteTo(seqNr: SeqNr): F[F[Unit]]
   }
 
+  /** Persisted data representation
+    */
   sealed trait Persisted[+A]
-  final case class HighestSeqNr(seqNr: SeqNr)       extends Persisted[Nothing]
+
+  /** Highest persisted [[SeqNr]] representation. Used as marker of sequence persisted number in case if events not available (were
+    * deleted).
+    *
+    * @param seqNr
+    *   (highest) persisted [[SeqNr]]
+    */
+  final case class HighestSeqNr(seqNr: SeqNr) extends Persisted[Nothing]
+
+  /** Persisted event representation
+    *
+    * @param event
+    *   domain event of type [[A]]
+    * @param seqNr
+    *   assosiated with event sequence number
+    */
   final case class Event[A](event: A, seqNr: SeqNr) extends Persisted[A]
 
 }

--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotStore.scala
@@ -2,17 +2,52 @@ package com.evolutiongaming.akkaeffect.persistence
 
 import java.time.Instant
 
+/** Persistent snapshot store API used in event-sourced actors [[EventSourcedActorOf]]. The API consists of two parts:
+  * [[SnapshotStore.Read]] and [[SnapshotStore.Write]] that represents looking up and persisting snapshots.
+  */
 trait SnapshotStore[F[_], A] extends SnapshotStore.Read[F, A] with SnapshotStore.Write[F, A]
 
 object SnapshotStore {
 
   trait Read[F[_], A] {
+
+    /** Get latest snapshot if any
+      *
+      * @return
+      *   snapshot offer if any
+      */
     def latest: F[Option[SnapshotStore.Offer[A]]]
   }
 
   trait Write[F[_], -A] {
+
+    /** Persist snapshot that represents state also achievable by applying events (on empty state) til sequence number.
+      *
+      * @param seqNr
+      *   sequence number of last event used to recover state equal to snapshot
+      * @param snapshot
+      *   the snapshot to be persisted
+      * @return
+      *   outer F represents request send while inner F represents request complete
+      */
     def save(seqNr: SeqNr, snapshot: A): F[F[Instant]]
+
+    /** Delete snapshots til the sequence number (including)
+      *
+      * @param seqNr
+      *   til which snapshots will be deleted
+      * @return
+      *   outer F represents request send while inner F represents request complete
+      */
     def delete(seqNr: SeqNr): F[F[Unit]]
+
+    /** Delete snapshots that satisfy criteria
+      *
+      * @param criteria
+      *   criteria of deletion
+      * @return
+      *   outer F represents request send while inner F represents request complete
+      */
     def delete(criteria: Criteria): F[F[Unit]]
   }
 

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -112,8 +112,8 @@ object EventStoreInterop {
 
                     case Left(l) =>
                       for {
-                        events <- buffer.getAndSet(Vector.empty)
                         done   <- actor.get
+                        events <- buffer.getAndSet(Vector.empty)
                         result <- events.foldWhileM(l)(f)
                         result <- result match {
 

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -76,8 +76,8 @@ object EventStoreInterop {
                         val buffer1 = buffer :+ event
                         buffer1 -> buffer1.length
                       }
-                      .flatMap { lenght =>
-                        if (lenght > capacity) {
+                      .flatMap { length =>
+                        if (length > capacity) {
                           new BufferOverflowException(capacity, persistenceId).raiseError[F, Either[Unit, SeqNr]]
                         } else {
                           ().asLeft[SeqNr].pure[F]

--- a/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
@@ -20,136 +20,138 @@ object EventStoreInterop {
     journalPluginId: String,
     eventSourcedId: EventSourcedId
   ): F[EventStore[F, A]] =
-    for {
-      appendedSeqNr <- Ref[F].of(SeqNr.Min)
-      journaller <- Sync[F].delay {
+    Sync[F]
+      .delay {
         val actorRef = Persistence(system).journalFor(journalPluginId)
         ActorEffect.fromActor(actorRef)
       }
-    } yield new EventStore[F, A] {
+      .map { journaller =>
+        new EventStore[F, A] {
 
-      import sstream.FoldWhile._
+          import sstream.FoldWhile._
 
-      val persistenceId = eventSourcedId.value
+          val persistenceId = eventSourcedId.value
 
-      override def from(seqNr: SeqNr): F[sstream.Stream[F, EventStore.Event[A]]] = {
+          override def events(fromSeqNr: SeqNr): F[sstream.Stream[F, EventStore.Persisted[A]]] = {
 
-        type Buffer = Vector[EventStore.Event[A]]
+            type Buffer = Vector[EventStore.Event[A]]
 
-        def actor(buffer: Ref[F, Buffer]) =
-          LocalActorRef[F, Unit, SeqNr]({}, timeout) {
+            def actor(buffer: Ref[F, Buffer]) =
+              LocalActorRef[F, Unit, SeqNr]({}, timeout) {
 
-            case (_, JournalProtocol.ReplayedMessage(persisted)) =>
-              if (persisted.deleted) ().asLeft[SeqNr].pure[F]
-              else {
-                val payload = persisted.payload.asInstanceOf[A]
-                val event   = EventStore.Event(payload, persisted.sequenceNr)
-                buffer.update(_ :+ event).as(().asLeft[SeqNr])
+                case (_, JournalProtocol.ReplayedMessage(persisted)) =>
+                  if (persisted.deleted) ().asLeft[SeqNr].pure[F]
+                  else {
+                    val payload = persisted.payload.asInstanceOf[A]
+                    val event   = EventStore.Event(payload, persisted.sequenceNr)
+                    buffer.update(_ :+ event).as(().asLeft[SeqNr])
+                  }
+
+                case (_, JournalProtocol.RecoverySuccess(seqNr)) =>
+                  seqNr.asRight[Unit].pure[F]
+
+                case (_, JournalProtocol.ReplayMessagesFailure(error)) =>
+                  error.raiseError[F, Either[Unit, SeqNr]]
               }
 
-            case (_, JournalProtocol.RecoverySuccess(seqNr)) =>
-              appendedSeqNr
-                .update(currentSeqNr => currentSeqNr max seqNr)
-                .as(seqNr.asRight[Unit])
+            for {
+              buffer <- Ref[F].of[Buffer](Vector.empty)
+              actor  <- actor(buffer)
+              request = JournalProtocol.ReplayMessages(fromSeqNr, SeqNr.Max, Long.MaxValue, persistenceId, actor.ref)
+              _      <- journaller.tell(request)
+            } yield new sstream.Stream[F, EventStore.Persisted[A]] {
 
-            case (_, JournalProtocol.ReplayMessagesFailure(error)) => error.raiseError[F, Either[Unit, SeqNr]]
+              override def foldWhileM[L, R](l: L)(f: (L, EventStore.Persisted[A]) => F[Either[L, R]]): F[Either[L, R]] =
+                l.asLeft[R]
+                  .tailRecM {
+
+                    case Left(l) =>
+                      for {
+                        events <- buffer.getAndSet(Vector.empty)
+                        done   <- actor.get
+                        result <- events.foldWhileM(l)(f)
+                        result <- result match {
+
+                          case Left(l) =>
+                            done match {
+
+                              case Some(Right(seqNr)) =>
+                                val event = EventStore.HighestSeqNr(seqNr)
+                                f(l, event).map { r =>
+                                  r.asRight[Either[L, R]]
+                                } // no more events but seqNr non 0, use PersistedSeqNr event to notify the actor
+
+                              case Some(Left(er)) =>
+                                er.raiseError[F, Either[Either[L, R], Either[L, R]]] // failure
+
+                              case None =>
+                                l.asLeft[R].asLeft[Either[L, R]].pure[F] // expecting more events
+                            }
+
+                          // Right(...), cos user-defined function [[f]] desided to stop consuming stream thus wrapping in Right to break tailRecM loop
+                          case result => result.asRight[Either[L, R]].pure[F]
+
+                        }
+                      } yield result
+
+                    case result => // cannot happened
+                      result.asRight[Either[L, R]].pure[F]
+                  }
+
+            }
+
           }
 
-        for {
-          buffer <- Ref[F].of[Buffer](Vector.empty)
-          actor  <- actor(buffer)
-          request = JournalProtocol.ReplayMessages(seqNr, SeqNr.Max, Long.MaxValue, persistenceId, actor.ref)
-          _      <- journaller.tell(request)
-        } yield new sstream.Stream[F, EventStore.Event[A]] {
+          override def save(events: Events[EventStore.Event[A]]): F[F[SeqNr]] = {
 
-          override def foldWhileM[L, R](l: L)(f: (L, EventStore.Event[A]) => F[Either[L, R]]): F[Either[L, R]] =
-            l.asLeft[R]
-              .tailRecM {
+            case class State(writes: Long, maxSeqNr: SeqNr)
+            val state = State(events.size, SeqNr.Min)
+            val actor = LocalActorRef[F, State, SeqNr](state, timeout) {
 
-                case Left(l) =>
-                  for {
-                    events <- buffer.getAndSet(Vector.empty)
-                    done   <- actor.get
-                    result <- events.foldWhileM(l)(f)
-                    result <- result match {
+              case (state, JournalProtocol.WriteMessagesSuccessful) => state.asLeft[SeqNr].pure[F]
 
-                      case l: Left[L, R] =>
-                        done match {
-                          case Some(Right(_)) => l.asRight[Either[L, R]].pure[F]                      // no more events
-                          case Some(Left(er)) => er.raiseError[F, Either[Either[L, R], Either[L, R]]] // failure
-                          case None           => l.asLeft[Either[L, R]].pure[F]                       // expecting more events
-                        }
+              case (state, JournalProtocol.WriteMessageSuccess(persistent, _)) =>
+                val seqNr = persistent.sequenceNr max state.maxSeqNr
+                val result =
+                  if (state.writes == 1) seqNr.asRight[State]
+                  else State(state.writes - 1, seqNr).asLeft[SeqNr]
+                result.pure[F]
 
-                      // Right(...), cos user-defined function [[f]] desided to stop consuming stream thus wrapping in Right to break tailRecM loop
-                      case result => result.asRight[Either[L, R]].pure[F]
+              case (_, JournalProtocol.WriteMessageRejected(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
 
-                    }
-                  } yield result
+              case (_, JournalProtocol.WriteMessagesFailed(error, _)) => error.raiseError[F, Either[State, SeqNr]]
 
-                case result => // cannot happened
-                  result.asRight[Either[L, R]].pure[F]
-              }
-
-        }
-
-      }
-
-      override def save(events: Events[A]): F[F[SeqNr]] = {
-
-        case class State(writes: Long, maxSeqNr: SeqNr)
-        val state = State(events.size, SeqNr.Min)
-        val actor = LocalActorRef[F, State, SeqNr](state, timeout) {
-
-          case (state, JournalProtocol.WriteMessagesSuccessful) => state.asLeft[SeqNr].pure[F]
-
-          case (state, JournalProtocol.WriteMessageSuccess(persistent, _)) =>
-            val seqNr = persistent.sequenceNr max state.maxSeqNr
-            val result =
-              if (state.writes == 1) seqNr.asRight[State]
-              else State(state.writes - 1, seqNr).asLeft[SeqNr]
-            result.pure[F]
-
-          case (_, JournalProtocol.WriteMessageRejected(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
-
-          case (_, JournalProtocol.WriteMessagesFailed(error, _)) => error.raiseError[F, Either[State, SeqNr]]
-
-          case (_, JournalProtocol.WriteMessageFailure(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
-        }
-
-        for {
-          messages <- appendedSeqNr.modify { seqNr =>
-            var _seqNr = seqNr
-            def nextSeqNr = {
-              _seqNr = _seqNr + 1
-              _seqNr
+              case (_, JournalProtocol.WriteMessageFailure(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
             }
+
             val messages = events.values.toList.map { events =>
-              val persistent = events.toList.map { event =>
-                PersistentRepr(event, persistenceId = persistenceId, sequenceNr = nextSeqNr)
+              val persistent = events.toList.map {
+                case EventStore.Event(event, seqNr) => PersistentRepr(event, persistenceId = persistenceId, sequenceNr = seqNr)
               }
               AtomicWrite(persistent)
             }
-            _seqNr -> messages
+
+            for {
+              actor  <- actor
+              request = JournalProtocol.WriteMessages(messages, actor.ref, 0)
+              _      <- journaller.tell(request)
+            } yield actor.res
           }
-          actor  <- actor
-          request = JournalProtocol.WriteMessages(messages, actor.ref, 0)
-          _      <- journaller.tell(request)
-        } yield actor.res
-      }
 
-      override def deleteTo(seqNr: SeqNr): F[F[Unit]] = {
+          override def deleteTo(seqNr: SeqNr): F[F[Unit]] = {
 
-        val actor = LocalActorRef[F, Unit, Unit]({}, timeout) {
-          case (_, DeleteMessagesSuccess(_))    => ().asRight[Unit].pure[F]
-          case (_, DeleteMessagesFailure(e, _)) => e.raiseError[F, Either[Unit, Unit]]
+            val actor = LocalActorRef[F, Unit, Unit]({}, timeout) {
+              case (_, DeleteMessagesSuccess(_))    => ().asRight[Unit].pure[F]
+              case (_, DeleteMessagesFailure(e, _)) => e.raiseError[F, Either[Unit, Unit]]
+            }
+
+            for {
+              actor  <- actor
+              request = JournalProtocol.DeleteMessagesTo(persistenceId, seqNr, actor.ref)
+              _      <- journaller.tell(request)
+            } yield actor.res
+          }
         }
-
-        for {
-          actor  <- actor
-          request = JournalProtocol.DeleteMessagesTo(persistenceId, seqNr, actor.ref)
-          _      <- journaller.tell(request)
-        } yield actor.res
       }
-    }
 
 }

--- a/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreinterop.scala
@@ -1,0 +1,155 @@
+package akka.persistence
+
+import akka.actor.ActorSystem
+
+import cats.syntax.all._
+import cats.effect.{Async, Sync, Ref}
+
+import com.evolutiongaming.akkaeffect.ActorEffect
+import com.evolutiongaming.akkaeffect.persistence.{EventStore, EventSourcedId, SeqNr, Events}
+import com.evolutiongaming.catshelper.{FromFuture, ToTry}
+import com.evolutiongaming.sstream
+
+import scala.concurrent.duration._
+
+object EventStoreInterop {
+
+  def apply[F[_]: Async: FromFuture: ToTry, A](
+    system: ActorSystem,
+    timeout: FiniteDuration,
+    journalPluginId: String,
+    eventSourcedId: EventSourcedId
+  ): F[EventStore[F, A]] =
+    for {
+      appendedSeqNr <- Ref[F].of(SeqNr.Min)
+      journaller <- Sync[F].delay {
+        val actorRef = Persistence(system).journalFor(journalPluginId)
+        ActorEffect.fromActor(actorRef)
+      }
+    } yield new EventStore[F, A] {
+
+      import sstream.FoldWhile._
+
+      val persistenceId = eventSourcedId.value
+
+      override def from(seqNr: SeqNr): F[sstream.Stream[F, EventStore.Event[A]]] = {
+
+        type Buffer = Vector[EventStore.Event[A]]
+
+        def actor(buffer: Ref[F, Buffer]) =
+          LocalActorRef[F, Unit, SeqNr]({}, timeout) {
+
+            case (_, JournalProtocol.ReplayedMessage(persisted)) =>
+              if (persisted.deleted) ().asLeft[SeqNr].pure[F]
+              else {
+                val payload = persisted.payload.asInstanceOf[A]
+                val event   = EventStore.Event(payload, persisted.sequenceNr)
+                buffer.update(_ :+ event).as(().asLeft[SeqNr])
+              }
+
+            case (_, JournalProtocol.RecoverySuccess(seqNr)) =>
+              appendedSeqNr
+                .update(currentSeqNr => currentSeqNr max seqNr)
+                .as(seqNr.asRight[Unit])
+
+            case (_, JournalProtocol.ReplayMessagesFailure(error)) => error.raiseError[F, Either[Unit, SeqNr]]
+          }
+
+        for {
+          buffer <- Ref[F].of[Buffer](Vector.empty)
+          actor  <- actor(buffer)
+          request = JournalProtocol.ReplayMessages(seqNr, SeqNr.Max, Long.MaxValue, persistenceId, actor.ref)
+          _      <- journaller.tell(request)
+        } yield new sstream.Stream[F, EventStore.Event[A]] {
+
+          override def foldWhileM[L, R](l: L)(f: (L, EventStore.Event[A]) => F[Either[L, R]]): F[Either[L, R]] =
+            l.asLeft[R]
+              .tailRecM {
+
+                case Left(l) =>
+                  for {
+                    events <- buffer.getAndSet(Vector.empty)
+                    done   <- actor.get
+                    result <- events.foldWhileM(l)(f)
+                    result <- result match {
+
+                      case l: Left[L, R] =>
+                        done match {
+                          case Some(Right(_)) => l.asRight[Either[L, R]].pure[F]                      // no more events
+                          case Some(Left(er)) => er.raiseError[F, Either[Either[L, R], Either[L, R]]] // failure
+                          case None           => l.asLeft[Either[L, R]].pure[F]                       // expecting more events
+                        }
+
+                      // Right(...), cos user-defined function [[f]] desided to stop consuming stream thus wrapping in Right to break tailRecM loop
+                      case result => result.asRight[Either[L, R]].pure[F]
+
+                    }
+                  } yield result
+
+                case result => // cannot happened
+                  result.asRight[Either[L, R]].pure[F]
+              }
+
+        }
+
+      }
+
+      override def save(events: Events[A]): F[F[SeqNr]] = {
+
+        case class State(writes: Long, maxSeqNr: SeqNr)
+        val state = State(events.size, SeqNr.Min)
+        val actor = LocalActorRef[F, State, SeqNr](state, timeout) {
+
+          case (state, JournalProtocol.WriteMessagesSuccessful) => state.asLeft[SeqNr].pure[F]
+
+          case (state, JournalProtocol.WriteMessageSuccess(persistent, _)) =>
+            val seqNr = persistent.sequenceNr max state.maxSeqNr
+            val result =
+              if (state.writes == 1) seqNr.asRight[State]
+              else State(state.writes - 1, seqNr).asLeft[SeqNr]
+            result.pure[F]
+
+          case (_, JournalProtocol.WriteMessageRejected(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
+
+          case (_, JournalProtocol.WriteMessagesFailed(error, _)) => error.raiseError[F, Either[State, SeqNr]]
+
+          case (_, JournalProtocol.WriteMessageFailure(_, error, _)) => error.raiseError[F, Either[State, SeqNr]]
+        }
+
+        for {
+          messages <- appendedSeqNr.modify { seqNr =>
+            var _seqNr = seqNr
+            def nextSeqNr = {
+              _seqNr = _seqNr + 1
+              _seqNr
+            }
+            val messages = events.values.toList.map { events =>
+              val persistent = events.toList.map { event =>
+                PersistentRepr(event, persistenceId = persistenceId, sequenceNr = nextSeqNr)
+              }
+              AtomicWrite(persistent)
+            }
+            _seqNr -> messages
+          }
+          actor  <- actor
+          request = JournalProtocol.WriteMessages(messages, actor.ref, 0)
+          _      <- journaller.tell(request)
+        } yield actor.res
+      }
+
+      override def deleteTo(seqNr: SeqNr): F[F[Unit]] = {
+
+        val actor = LocalActorRef[F, Unit, Unit]({}, timeout) {
+          case (_, DeleteMessagesSuccess(_))    => ().asRight[Unit].pure[F]
+          case (_, DeleteMessagesFailure(e, _)) => e.raiseError[F, Either[Unit, Unit]]
+        }
+
+        for {
+          actor  <- actor
+          request = JournalProtocol.DeleteMessagesTo(persistenceId, seqNr, actor.ref)
+          _      <- journaller.tell(request)
+        } yield actor.res
+      }
+    }
+
+}

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
 
 /** Representation of actor capable of constructing result from multiple messages passed into the actor. Inspired by [[PromiseActorRef]] but
-  * result [[R]] is an aggregate from incomming messages rather that first message. Can be used only locally, does _not_ tolerate.
+  * result [[R]] is an aggregate from incoming messages rather that first message. Can be used only locally, does _not_ tolerate.
   * [[ActorRef.provider]] and [[ActorRef.path]] functions.
   * @tparam F
   *   The effect type.
@@ -24,6 +24,9 @@ import scala.concurrent.duration.FiniteDuration
   */
 private[persistence] trait LocalActorRef[F[_], R] {
 
+  /** Not actual [[ActorRef]]! It is not serialisable thus chould not be passed via network. Under the hood it implements [[ActorRef]] trait
+    * by providing function `!` that updates internal state using provided function `receive`. Please check [[LocalActorRef.apply]] docs
+    */
   def ref: ActorRef
 
   /** Semantically blocking while aggregating result
@@ -50,9 +53,9 @@ private[persistence] object LocalActorRef {
     * @param initial
     *   The initial state of type [[S]].
     * @param timeout
-    *   [[TimeoutException]] will be thrown if no incomming messages received within the timeout.
+    *   [[TimeoutException]] will be thrown if no incoming messages received within the timeout.
     * @param receive
-    *   The aggregate function defining how to apply incomming message on state or produce final result: [[Left]] for continue aggregating
+    *   The aggregate function defining how to apply incoming message on state or produce final result: [[Left]] for continue aggregating
     *   while [[Right]] for the result.
     * @tparam F
     *   The effect type.

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -1,0 +1,134 @@
+package akka.persistence
+
+import akka.actor.{ActorRef, MinimalActorRef}
+import cats.effect.Temporal
+import cats.syntax.all._
+import com.evolutiongaming.catshelper.CatsHelper.OpsCatsHelper
+import com.evolutiongaming.catshelper.{SerialRef, ToTry}
+import scala.concurrent.duration.FiniteDuration
+import java.time.Instant
+import java.util.concurrent.TimeoutException
+import java.time.temporal.ChronoUnit
+
+/** Representation of actor capable of constructing result from multiple messages passed into the actor. Inspired by [[PromiseActorRef]] but
+  * result [[R]] is an aggregate from incomming messages rather that first message. Can be used only locally, does _not_ tolerate.
+  * [[ActorRef.provider]] and [[ActorRef.path]] functions.
+  * @tparam F
+  *   The effect type.
+  * @tparam R
+  *   The result type of the aggregate.
+  */
+private[persistence] trait LocalActorRef[F[_], R] {
+
+  def ref: ActorRef
+
+  /** Semantically blocking while aggregating result
+    */
+  def res: F[R]
+
+  /** Immidiately get currect state:
+    *
+    * \- [[None]] if aggregating not finished yet
+    *
+    * \- [[Some(Left(Throwable))]] if aggregation failed or timeout happened
+    *
+    * \- [[Some(Right(r))]] if aggregation completed successfully
+    */
+  def get: F[Option[Either[Throwable, R]]]
+}
+
+private[persistence] object LocalActorRef {
+
+  type M = Any
+
+  /** Create new [[LocalActorRef]]
+    *
+    * @param initial
+    *   The initial state of type [[S]].
+    * @param timeout
+    *   [[TimeoutException]] will be thrown if no incomming messages received within the timeout.
+    * @param receive
+    *   The aggregate function defining how to apply incomming message on state or produce final result: [[Left]] for continue aggregating
+    *   while [[Right]] for the result.
+    * @tparam F
+    *   The effect type.
+    * @tparam S
+    *   The aggregating state type.
+    * @tparam R
+    *   The final result type.
+    * @return
+    */
+  def apply[F[_]: Temporal: ToTry, S, R](initial: S, timeout: FiniteDuration)(
+    receive: PartialFunction[(S, M), F[Either[S, R]]]
+  ): F[LocalActorRef[F, R]] = {
+
+    val F = Temporal[F]
+
+    case class State(state: S, updated: Instant)
+
+    def timeoutException = new TimeoutException(s"no messages received during period of $timeout")
+
+    for {
+      now   <- F.realTimeInstant
+      state <- SerialRef.of[F, State](State(initial, now))
+      defer <- F.deferred[Either[Throwable, R]]
+      fiber <- F.start {
+        val f = for {
+          _ <- F.sleep(timeout)
+          s <- state.get
+          n <- F.realTimeInstant
+          c  = s.updated.plus(timeout.toNanos, ChronoUnit.NANOS).isBefore(n)
+          _ <- if (c) defer.complete(timeoutException.asLeft) else F.unit
+        } yield c
+
+        ().tailRecM { _ =>
+          f.ifF(().asRight, ().asLeft)
+        }
+      }
+    } yield new LocalActorRef[F, R] {
+
+      private def done(e: Either[Throwable, R]) =
+        for {
+          _ <- defer.complete(e)
+          _ <- fiber.cancel
+        } yield {}
+
+      override def ref: ActorRef = new MinimalActorRef {
+
+        override def provider = throw new UnsupportedOperationException()
+
+        override def path = throw new UnsupportedOperationException()
+
+        override def !(m: M)(implicit sender: ActorRef): Unit =
+          state
+            .update { s =>
+              if (receive.isDefinedAt(s.state -> m)) {
+
+                for {
+                  t <- Temporal[F].realTimeInstant
+                  r <- receive(s.state -> m)
+                  s <- r match {
+                    case Left(s)  => State(s, t).pure[F]
+                    case Right(r) => done(r.asRight).as(s)
+                  }
+                } yield s
+
+              } else {
+                s.pure[F]
+              }
+            }
+            .handleErrorWith { e =>
+              done(e.asLeft).void
+            }
+            .toTry
+            .get
+
+      }
+
+      override def res: F[R] = defer.get.flatMap(_.liftTo[F])
+
+      override def get: F[Option[Either[Throwable, R]]] = defer.tryGet
+    }
+  }
+
+}

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -1,0 +1,108 @@
+package akka.persistence
+
+import akka.actor.ActorSystem
+import akka.persistence.SnapshotSelectionCriteria
+
+import cats.syntax.all._
+import cats.effect.Sync
+
+import com.evolutiongaming.catshelper.FromFuture
+import com.evolutiongaming.akkaeffect.ActorEffect
+import com.evolutiongaming.akkaeffect.persistence.{SnapshotStore, EventSourcedId, SeqNr}
+
+import scala.concurrent.duration._
+import java.time.Instant
+
+object SnapshotStoreInterop {
+
+  def apply[F[_]: Sync: FromFuture, A](
+    system: ActorSystem,
+    timeout: FiniteDuration,
+    snapshotPluginId: String,
+    eventSourcedId: EventSourcedId
+  ): F[SnapshotStore[F, A]] =
+    Sync[F]
+      .delay {
+        val actorRef = Persistence(system).snapshotStoreFor(snapshotPluginId)
+        ActorEffect.fromActor(actorRef)
+      }
+      .map { snapshotter =>
+        new SnapshotStore[F, A] {
+
+          val persistenceId = eventSourcedId.value
+
+          override def latest: F[Option[SnapshotStore.Offer[A]]] = {
+            val criteria = SnapshotSelectionCriteria()
+            val request  = SnapshotProtocol.LoadSnapshot(persistenceId, criteria, Long.MaxValue)
+            snapshotter
+              .ask(request, timeout)
+              .flatMap { response =>
+                response.flatMap {
+
+                  case SnapshotProtocol.LoadSnapshotResult(snapshot, _) =>
+                    snapshot match {
+
+                      case Some(offer) =>
+                        val payload   = offer.snapshot.asInstanceOf[A]
+                        val timestamp = Instant.ofEpochMilli(offer.metadata.timestamp)
+                        val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp)
+                        SnapshotStore.Offer(payload, metadata).some.pure[F]
+
+                      case None => none[SnapshotStore.Offer[A]].pure[F]
+                    }
+
+                  case SnapshotProtocol.LoadSnapshotFailed(err) =>
+                    err.raiseError[F, Option[SnapshotStore.Offer[A]]]
+                }
+              }
+          }
+
+          override def save(seqNr: SeqNr, snapshot: A): F[F[Instant]] = {
+            val metadata = SnapshotMetadata(persistenceId, seqNr)
+            val request  = SnapshotProtocol.SaveSnapshot(metadata, snapshot)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case SaveSnapshotSuccess(metadata) => Instant.ofEpochMilli(metadata.timestamp).pure[F]
+                  case SaveSnapshotFailure(_, err)   => err.raiseError[F, Instant]
+                }
+
+              }
+          }
+
+          override def delete(seqNr: SeqNr): F[F[Unit]] = {
+            val metadata = SnapshotMetadata(persistenceId, seqNr)
+            val request  = SnapshotProtocol.DeleteSnapshot(metadata)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case DeleteSnapshotSuccess(_)      => ().pure[F]
+                  case DeleteSnapshotFailure(_, err) => err.raiseError[F, Unit]
+                }
+              }
+          }
+
+          override def delete(criteria: SnapshotStore.Criteria): F[F[Unit]] = {
+            val query = SnapshotSelectionCriteria(
+              maxSequenceNr = criteria.maxSequenceNr,
+              maxTimestamp = criteria.maxTimestamp,
+              minSequenceNr = criteria.minSequenceNr,
+              minTimestamp = criteria.minTimestamp
+            )
+            val request = SnapshotProtocol.DeleteSnapshots(persistenceId, query)
+            snapshotter
+              .ask(request, timeout)
+              .map { response =>
+                response.flatMap {
+                  case DeleteSnapshotsSuccess(_)      => ().pure[F]
+                  case DeleteSnapshotsFailure(_, err) => err.raiseError[F, Unit]
+                }
+              }
+          }
+
+        }
+      }
+
+}

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
@@ -1,0 +1,25 @@
+package com.evolutiongaming.akkaeffect.persistence
+
+import akka.actor.Props
+import cats.effect.{Async, Resource}
+import com.evolutiongaming.akkaeffect.{ActorEffect, ActorRefOf}
+import com.evolutiongaming.catshelper.{FromFuture, ToFuture, ToTry}
+
+object EventSourcedActorEffect {
+
+  def of[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorRefOf: ActorRefOf[F],
+    eventSourcedOf: EventSourcedOf[F, EventSourcedActorOf.Lifecycle[F, Any, Any, Any]],
+    persistence: EventSourcedPersistence[F],
+    name: Option[String] = None
+  ): Resource[F, ActorEffect[F, Any, Any]] = {
+
+    def actor = EventSourcedActorOf.actor[F, Any, Any, Any](eventSourcedOf, persistence)
+
+    val props = Props(actor)
+
+    actorRefOf(props, name)
+      .map(actorRef => ActorEffect.fromActor(actorRef))
+  }
+
+}

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -1,0 +1,135 @@
+package com.evolutiongaming.akkaeffect.persistence
+
+import akka.actor.Actor
+import akka.persistence.SnapshotSelectionCriteria
+
+import cats.effect.implicits.effectResourceOps
+import cats.effect.{Async, Resource, Ref}
+import cats.syntax.all._
+
+import com.evolutiongaming.akkaeffect._
+import com.evolutiongaming.catshelper.ToFuture
+
+import scala.reflect.ClassTag
+import java.time.Instant
+
+object EventSourcedActorOf {
+
+  /** Describes lifecycle of entity with regards to event sourcing & PersistentActor Lifecycle phases:
+    *
+    *   1. RecoveryStarted: we have id in place and can decide whether we should continue with recovery 
+    *   2. Recovering : reading snapshot and replaying events 
+    *   3. Receiving : receiving commands and potentially storing events & snapshots 
+    *   4. Termination : triggers all release hooks of allocated resources within previous phases
+    *
+    * @tparam S snapshot
+    * @tparam E event
+    * @tparam C command
+    */
+  type Lifecycle[F[_], S, E, C] =
+    Resource[F, RecoveryStarted[F, S, E, Receive[F, Envelope[C], ActorOf.Stop]]]
+
+  def actor[F[_]: Async: ToFuture, S, E, C: ClassTag](
+    eventSourcedOf: EventSourcedOf[F, Lifecycle[F, S, E, C]],
+    persistence: EventSourcedPersistence[F]
+  ): Actor = ActorOf[F] { actorCtx =>
+    for {
+      eventSourced    <- eventSourcedOf(actorCtx).toResource
+      recoveryStarted <- eventSourced.value
+
+      snapshotStore <- persistence.snapshotStore[S](eventSourced).toResource
+      eventStore    <- persistence.eventStore[E](eventSourced).toResource
+
+      snapshot <- snapshotStore.latest.toResource
+
+      recovering <- recoveryStarted(
+        snapshot.map(_.metadata.seqNr).getOrElse(SeqNr.Min),
+        snapshot.map(_.asOffer)
+      )
+
+      seqNr <- recovering.replay.use { replay =>
+        val snapSeqNr = snapshot.map(_.metadata.seqNr).getOrElse(SeqNr.Min)
+        val fromSeqNr = snapshot.map(_.metadata.seqNr + 1).getOrElse(SeqNr.Min)
+        for {
+          events <- eventStore.events(fromSeqNr)
+          seqNrL <- events.foldWhileM(snapSeqNr) {
+            case (_, EventStore.Event(event, seqNr)) => replay(event, seqNr).as(seqNr.asLeft[Unit])
+            case (_, EventStore.HighestSeqNr(seqNr)) => seqNr.asLeft[Unit].pure[F]
+          }
+          seqNr <- seqNrL
+            .as(new IllegalStateException("should newer happened"))
+            .swap
+            .liftTo[F]
+        } yield seqNr
+      }.toResource
+
+      currentSeqNr <- Ref[F].of(seqNr).toResource
+
+      snapshotter = new Snapshotter[F, S] {
+
+        def save(seqNr: SeqNr, snapshot: S): F[F[Instant]] = snapshotStore.save(seqNr, snapshot)
+
+        def delete(seqNr: SeqNr): F[F[Unit]] = snapshotStore.delete(seqNr)
+
+        def delete(criteria: SnapshotSelectionCriteria): F[F[Unit]] = snapshotStore.delete(criteria.asStoreCriteria)
+
+      }
+
+      journaller = new Journaller[F, E] {
+
+        val append = new Append[F, E] {
+
+          def apply(events: Events[E]): F[F[SeqNr]] =
+            currentSeqNr
+              .modify { seqNr0 =>
+                val seqNr1 = seqNr0 + events.size
+                seqNr1 -> seqNr0
+              }
+              .map { seqNr0 =>
+                var seqNr = seqNr0
+                def nextSeqNr: SeqNr = {
+                  seqNr = seqNr + 1
+                  seqNr
+                }
+                events.map(e => EventStore.Event(e, nextSeqNr))
+              }
+              .flatMap { events =>
+                eventStore.save(events)
+              }
+
+        }
+
+        val deleteTo = new DeleteEventsTo[F] {
+
+          def apply(seqNr: SeqNr): F[F[Unit]] = eventStore.deleteTo(seqNr)
+
+        }
+
+      }
+
+      receive <- recovering.completed(seqNr, journaller, snapshotter)
+    } yield receive.contramapM[Envelope[Any]](_.cast[F, C])
+  }
+
+  implicit private class SnapshotOps[S](val snapshot: SnapshotStore.Offer[S]) extends AnyVal {
+
+    def asOffer: SnapshotOffer[S] =
+      SnapshotOffer(
+        SnapshotMetadata(snapshot.metadata.seqNr, snapshot.metadata.timestamp),
+        snapshot.snapshot
+      )
+
+  }
+
+  implicit private class CriteriaOps(val criteria: SnapshotSelectionCriteria) extends AnyVal {
+
+    def asStoreCriteria: SnapshotStore.Criteria =
+      SnapshotStore.Criteria(
+        maxSequenceNr = criteria.maxSequenceNr,
+        maxTimestamp = criteria.maxTimestamp,
+        minSequenceNr = criteria.minSequenceNr,
+        minTimestamp = criteria.minTimestamp
+      )
+  }
+
+}

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -41,7 +41,7 @@ object EventSourcedActorOf {
       * Actor' lifecycle described by type [[Lifecycle]] and consists of multiple phases, 
       * such as recovering, receiving messages and terminating. Recovery happeneds on actor' startup 
       * and is about constucting latest actor' state from snapshot and followed events. On receiving phase
-      * actor handles incomming commands and chages its state. Each state' change represented by events,
+      * actor handles incoming commands and chages its state. Each state' change represented by events,
       * that are persisted and later used in recovery phase. Terminating happeneds on actor shutdown
       * (technically it happens as part of [[Actor.postStop]], check [[ActorOf]] for more details).
       * 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -22,9 +22,9 @@ object EventSourcedActorOf {
     *   3. Receiving : receiving commands and potentially storing events & snapshots 
     *   4. Termination : triggers all release hooks of allocated resources within previous phases
     * 
-    * Types, describing each phace, are (simplified) a functions from data (available on the current phace) 
-    * to next phace: RecoveryStarted -> Recovering -> Receiving. Termination phace described via aggregation
-    * of [[Resource]] releace callbacks. Please refer to phace types for more details.
+    * Types, describing each phase, are (simplified) a functions from data (available on the current phase) 
+    * to next phase: RecoveryStarted -> Recovering -> Receiving. Termination phase described via aggregation
+    * of [[Resource]] release callbacks. Please refer to phase types for more details.
     *
     * @tparam S snapshot
     * @tparam E event
@@ -42,7 +42,7 @@ object EventSourcedActorOf {
       * such as recovering, receiving messages and terminating. Recovery happeneds on actor' startup 
       * and is about constucting latest actor' state from snapshot and followed events. On receiving phase
       * actor handles incomming commands and chages its state. Each state' change represented by events,
-      * that are persisted and later used in recovery phace. Terminating happeneds on actor shutdown
+      * that are persisted and later used in recovery phase. Terminating happeneds on actor shutdown
       * (technically it happens as part of [[Actor.postStop]], check [[ActorOf]] for more details).
       * 
       * Persistence layer, used to store/recover events and snapshots, provided by [[EventSourcedPersistence]].  

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
@@ -1,0 +1,40 @@
+package com.evolutiongaming.akkaeffect.persistence
+
+import akka.actor.ActorSystem
+import akka.persistence.SnapshotStoreInterop
+import akka.persistence.EventStoreInterop
+
+import cats.effect.Async
+
+import com.evolutiongaming.catshelper.FromFuture
+import com.evolutiongaming.catshelper.ToTry
+
+import scala.concurrent.duration._
+
+trait EventSourcedPersistence[F[_]] {
+
+  def snapshotStore[A](eventSourced: EventSourced[_]): F[SnapshotStore[F, A]]
+
+  def eventStore[A](eventSourced: EventSourced[_]): F[EventStore[F, A]]
+
+}
+
+object EventSourcedPersistence {
+
+  def fromAkkaPlugins[F[_]: Async: FromFuture: ToTry](
+    system: ActorSystem,
+    timeout: FiniteDuration
+  ): EventSourcedPersistence[F] = new EventSourcedPersistence[F] {
+
+    override def snapshotStore[A](eventSourced: EventSourced[_]): F[SnapshotStore[F, A]] = {
+      val pluginId = eventSourced.pluginIds.snapshot.getOrElse("")
+      SnapshotStoreInterop[F, A](system, timeout, pluginId, eventSourced.eventSourcedId)
+    }
+
+    override def eventStore[A](eventSourced: EventSourced[_]): F[EventStore[F, A]] = {
+      val pluginId = eventSourced.pluginIds.journal.getOrElse("")
+      EventStoreInterop[F, A](system, timeout, pluginId, eventSourced.eventSourcedId)
+    }
+  }
+
+}

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
@@ -1,11 +1,9 @@
 package com.evolutiongaming.akkaeffect.persistence
 
 import akka.actor.ActorSystem
-import akka.persistence.SnapshotStoreInterop
 import akka.persistence.EventStoreInterop
-
+import akka.persistence.SnapshotStoreInterop
 import cats.effect.Async
-
 import com.evolutiongaming.catshelper.FromFuture
 import com.evolutiongaming.catshelper.ToTry
 
@@ -23,7 +21,8 @@ object EventSourcedPersistence {
 
   def fromAkkaPlugins[F[_]: Async: FromFuture: ToTry](
     system: ActorSystem,
-    timeout: FiniteDuration
+    timeout: FiniteDuration,
+    capacity: Int
   ): EventSourcedPersistence[F] = new EventSourcedPersistence[F] {
 
     override def snapshotStore[A](eventSourced: EventSourced[_]): F[SnapshotStore[F, A]] = {
@@ -33,7 +32,7 @@ object EventSourcedPersistence {
 
     override def eventStore[A](eventSourced: EventSourced[_]): F[EventStore[F, A]] = {
       val pluginId = eventSourced.pluginIds.journal.getOrElse("")
-      EventStoreInterop[F, A](system, timeout, pluginId, eventSourced.eventSourcedId)
+      EventStoreInterop[F, A](system, timeout, capacity, pluginId, eventSourced.eventSourcedId)
     }
   }
 

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -1,0 +1,198 @@
+package akka.persistence
+
+import akka.persistence.journal.AsyncWriteJournal
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+
+import com.evolutiongaming.akkaeffect.persistence.EventSourcedId
+import com.evolutiongaming.akkaeffect.persistence.Events
+import com.evolutiongaming.akkaeffect.persistence.SeqNr
+import com.evolutiongaming.akkaeffect.persistence.EventStore
+import com.evolutiongaming.akkaeffect.testkit.TestActorSystem
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.collection.immutable.Seq
+import scala.util.Try
+
+class EventStoreInteropTest extends AnyFunSuite with Matchers {
+
+  val emptyPluginId = ""
+
+  test("journal: replay (nothing), save, replay, delete, replay") {
+
+    val persistenceId = EventSourcedId("#11")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List.empty[EventStore.Event[String]]
+          seqNr  <- store.save(Events.of("first", "second")).flatten
+          _       = seqNr shouldEqual 2L
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List(EventStore.Event("first", 1L), EventStore.Event("second", 2L))
+          _      <- store.deleteTo(1L).flatten
+          events <- store.from(SeqNr.Min)
+          events <- events.toList
+          _       = events shouldEqual List(EventStore.Event("second", 2L))
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail loading events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#11")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          error  <- events.toList.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[List[EventStore.Event[String]]]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail persisting events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#12")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          seqNr <- store.save(Events.of[String]("first", "second"))
+          error <- seqNr.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[SeqNr]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: fail deleting events") {
+
+    val pluginId      = "failing-journal"
+    val persistenceId = EventSourcedId("#13")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.deleteTo(SeqNr.Max)
+          error    <- deleting.attempt
+        } yield error shouldEqual FailingJournal.exception.asLeft[Unit]
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout on loading events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#14")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          events <- store.from(SeqNr.Min)
+          error  <- events.toList.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout persisting events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#15")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          seqNr <- store.save(Events.of[String]("first", "second"))
+          error <- seqNr.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("journal: timeout deleting events") {
+
+    val pluginId      = "infinite-journal"
+    val persistenceId = EventSourcedId("#16")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- EventStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.deleteTo(SeqNr.Max)
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: TimeoutException) => succeed
+          case Left(e)                   => fail(e)
+          case Right(r)                  => fail(s"the test should fail with TimeoutException while actual result is $r")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+}
+
+object FailingJournal {
+  val exception = new RuntimeException("test exception")
+}
+
+class FailingJournal extends AsyncWriteJournal {
+
+  override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
+    recoveryCallback: PersistentRepr => Unit
+  ): Future[Unit] = Future.failed(FailingJournal.exception)
+
+  override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
+    Future.failed(FailingJournal.exception)
+
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.failed(FailingJournal.exception)
+
+  override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = Future.failed(FailingJournal.exception)
+
+}
+
+class InfiniteJournal extends AsyncWriteJournal {
+
+  override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
+    recoveryCallback: PersistentRepr => Unit
+  ): Future[Unit] = Future.never
+
+  override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = Future.never
+
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.never
+
+  override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = Future.never
+
+}

--- a/persistence/src/test/scala/akka/persistence/LocalActorRefTest.scala
+++ b/persistence/src/test/scala/akka/persistence/LocalActorRefTest.scala
@@ -1,0 +1,101 @@
+package akka.persistence
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
+
+class LocalActorRefTest extends AnyFunSuite with Matchers {
+
+  val poison  = 100500
+  val timeout = 1.second
+
+  def of = LocalActorRef[IO, Int, Int](0, timeout) {
+    case (s, `poison`) => IO(s.asRight)
+    case (s, m: Int)   => IO((s + m).asLeft)
+  }
+
+  test("LocalActorRef can handle messages and produce result") {
+    val io = for {
+      r <- of
+      n <- r.get
+      _  = n shouldEqual none
+      _ <- IO(r.ref ! 3)
+      _ <- IO(r.ref ! 4)
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual 7
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef.res semantically blocks until result produced") {
+    val io = for {
+      d  <- IO.deferred[Unit]
+      r  <- of
+      f   = r.res >> d.complete {}
+      f  <- f.start
+      d0 <- d.tryGet
+      _   = d0 shouldEqual none
+      _  <- IO(r.ref ! poison)
+      _  <- f.join
+      d1 <- d.tryGet
+      _   = d1 shouldEqual {}.some
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef should handle concurrent ! operations") {
+    val io = for {
+      r <- of
+      l  = List.range(0, 100)
+      _ <- l.parTraverse(i => IO(r.ref ! i))
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual l.sum
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test(s"LocalActorRef should timeout aftet $timeout") {
+    val io = for {
+      r <- of
+      _ <- IO.sleep(timeout * 2)
+      e <- r.get
+      _ = e match {
+        case Some(Left(_: TimeoutException)) => succeed
+        case other                           => fail(s"unexpected result $other")
+      }
+      e <- r.res.attempt
+      _ = e match {
+        case Left(_: TimeoutException) => succeed
+        case other                     => fail(s"unexpected result $other")
+      }
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+  test("LocalActorRef should not timeout while receiving messages within timeout span") {
+    val io = for {
+      r <- of
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! 2)
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! 3)
+      _ <- IO.sleep(timeout / 2)
+      _ <- IO(r.ref ! poison)
+      r <- r.res
+      _  = r shouldEqual 5
+    } yield {}
+
+    io.unsafeRunSync()
+  }
+
+}

--- a/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
@@ -1,0 +1,253 @@
+package akka.persistence
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import cats.syntax.all._
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+
+import com.evolutiongaming.akkaeffect.persistence.{EventSourcedId, SeqNr, SnapshotStore}
+import com.evolutiongaming.akkaeffect.testkit.TestActorSystem
+
+import scala.util.Random
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import akka.pattern.AskTimeoutException
+import java.time.Instant
+
+class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
+
+  val emptyPluginId = ""
+
+  test("snapshot: load, save and load again") {
+
+    val persistenceId = EventSourcedId("#1")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          snapshot <- store.latest
+          _         = snapshot shouldEqual none
+          _        <- store.save(SeqNr.Min, payload).flatten
+          snapshot <- store.latest
+          _         = snapshot.get.snapshot should equal(payload)
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: save, load, delete and load again") {
+
+    val persistenceId = EventSourcedId("#2")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, emptyPluginId, persistenceId)
+          _        <- store.save(SeqNr.Min, payload).flatten
+          snapshot <- store.latest
+          _         = snapshot.get.snapshot should equal(payload)
+          _        <- store.delete(SeqNr.Min).flatten
+          snapshot <- store.latest
+          _         = snapshot shouldEqual none
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail load snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#3")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          error <- store.latest.attempt
+          _      = error shouldEqual FailingSnapshotter.exception.asLeft[List[SnapshotStore.Offer[String]]]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail save snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#4")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          saving <- store.save(SeqNr.Min, payload)
+          error  <- saving.attempt
+          _       = error shouldEqual FailingSnapshotter.exception.asLeft[Instant]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail delete snapshot") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#5")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SeqNr.Min)
+          error    <- deleting.attempt
+          _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: fail delete snapshot by criteria") {
+
+    val pluginId      = "failing-snapshot"
+    val persistenceId = EventSourcedId("#6")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SnapshotStore.Criteria())
+          error    <- deleting.attempt
+          _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout loading snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#7")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use(system =>
+        for {
+          store <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          error <- store.latest.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      )
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout saving snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#8")
+    val payload       = Random.nextString(1024)
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store  <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          saving <- store.save(SeqNr.Min, payload)
+          error  <- saving.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout deleting snapshot") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#9")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SeqNr.Min)
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+  test("snapshot: timeout deleting snapshot by criteria") {
+
+    val pluginId      = "infinite-snapshot"
+    val persistenceId = EventSourcedId("#10")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        for {
+          store    <- SnapshotStoreInterop[IO, String](system, 1.second, pluginId, persistenceId)
+          deleting <- store.delete(SnapshotStore.Criteria())
+          error    <- deleting.attempt
+        } yield error match {
+          case Left(_: AskTimeoutException) => succeed
+          case Left(other)                  => fail(other)
+          case Right(_)                     => fail("the test should fail with AskTimeoutException but did no")
+        }
+      }
+
+    io.unsafeRunSync()
+  }
+
+}
+
+object FailingSnapshotter {
+
+  val exception = new RuntimeException("test exception")
+
+}
+
+class FailingSnapshotter extends akka.persistence.snapshot.SnapshotStore {
+
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] =
+    Future.failed(FailingSnapshotter.exception)
+
+  override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = Future.failed(FailingSnapshotter.exception)
+
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = Future.failed(FailingSnapshotter.exception)
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] =
+    Future.failed(FailingSnapshotter.exception)
+
+}
+
+class InfiniteSnapshotter extends akka.persistence.snapshot.SnapshotStore {
+
+  override def loadAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = Future.never
+
+  override def saveAsync(metadata: SnapshotMetadata, snapshot: Any): Future[Unit] = Future.never
+
+  override def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = Future.never
+
+  override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = Future.never
+
+}

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
@@ -72,7 +72,7 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
     setReceiveTimeout[IO](actorSystem).run()
   }
 
-  private def persistence[F[_]: Async: FromFuture: ToTry] = EventSourcedPersistence.fromAkkaPlugins[F](actorSystem, 1.second)
+  private def persistence[F[_]: Async: FromFuture: ToTry] = EventSourcedPersistence.fromAkkaPlugins[F](actorSystem, 1.second, 1000)
 
   private def `persistentActorOf`[F[_]: Async: ToFuture: FromFuture: ToTry](
     actorSystem: ActorSystem

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
@@ -1,0 +1,1100 @@
+package com.evolutiongaming.akkaeffect.persistence
+
+import java.time.Instant
+import akka.actor.{ActorIdentity, ActorRef, ActorSystem, Identify}
+import akka.persistence.Recovery
+import akka.testkit.TestActors
+import cats.data.{NonEmptyList => Nel}
+import cats.effect.kernel.Ref
+import cats.effect.{Async, Deferred, IO, Resource, Sync, Temporal}
+import cats.effect.syntax.all._
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import com.evolutiongaming.akkaeffect.IOSuite._
+import com.evolutiongaming.akkaeffect.persistence.InstrumentEventSourced.Action
+import com.evolutiongaming.akkaeffect.testkit.Probe
+import com.evolutiongaming.akkaeffect.{ActorSuite, _}
+import com.evolutiongaming.catshelper.CatsHelper._
+import com.evolutiongaming.catshelper.{FromFuture, ToFuture, ToTry}
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matchers {
+
+  test("all") {
+    `persistentActorOf`[IO](actorSystem).run()
+  }
+
+  test("recover with empty state") {
+    `recover with empty state`[IO](actorSystem).run()
+  }
+
+  test("recover from snapshot") {
+    `recover from snapshot`[IO](actorSystem).run()
+  }
+
+  test("recover from snapshot with deleted events") {
+    `recover from snapshot with deleted events`[IO](actorSystem).run()
+  }
+
+  test("recover from events") {
+    `recover from events`[IO](actorSystem).run()
+  }
+
+  test("recover from events with deleted snapshot") {
+    `recover from events with deleted snapshot`[IO](actorSystem).run()
+  }
+
+  test("recover from snapshot and events") {
+    `recover from snapshot and events`[IO](actorSystem).run()
+  }
+
+  test("start stops") {
+    `start stops`[IO](actorSystem).run()
+  }
+
+  test("recoveryStarted stops") {
+    `recoveryStarted stops`[IO](actorSystem).run()
+  }
+
+  test("recoveryCompleted stops") {
+    `recoveryCompleted stops`[IO](actorSystem).run()
+  }
+
+  test("append many") {
+    `append many`[IO](actorSystem).run()
+  }
+
+  test("setReceiveTimeout") {
+    setReceiveTimeout[IO](actorSystem).run()
+  }
+
+  private def persistence[F[_]: Async: FromFuture: ToTry] = EventSourcedPersistence.fromAkkaPlugins[F](actorSystem, 1.second)
+
+  private def `persistentActorOf`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+
+    type State = Int
+    type Event = String
+
+    sealed trait Cmd
+
+    object Cmd {
+      final case object Inc                               extends Cmd
+      final case object Stop                              extends Cmd
+      final case class WithCtx[A](f: ActorCtx[F] => F[A]) extends Cmd
+    }
+
+    def eventSourcedOf(
+      receiveTimeout: F[Unit]
+    ): EventSourcedOf[F, Resource[F, RecoveryStarted[F, State, Event, Receive[F, Envelope[Any], Boolean]]]] =
+      EventSourcedOf[F] { actorCtx =>
+        val recoveryStarted =
+          RecoveryStarted
+            .const {
+              Recovering[State] {
+                Replay.empty[F, Event].pure[Resource[F, *]]
+              } { (_, journaller, snapshotter) =>
+                for {
+                  stateRef <- Ref[F].of(0).toResource
+                } yield Receive[Envelope[Cmd]] { envelope =>
+                  val reply = Reply.fromActorRef[F](to = envelope.from, from = actorCtx.self)
+
+                  envelope.msg match {
+                    case a: Cmd.WithCtx[_] =>
+                      for {
+                        a <- a.f(actorCtx)
+                        _ <- reply(a)
+                      } yield false
+
+                    case Cmd.Inc =>
+                      for {
+                        seqNr  <- journaller.append(Events.of("a")).flatten
+                        _      <- stateRef.update(_ + 1)
+                        state  <- stateRef.get
+                        result <- snapshotter.save(seqNr, state)
+                        seqNr  <- journaller.append(Events.batched(Nel.of("b"), Nel.of("c", "d"))).flatten
+                        _      <- result
+                        _      <- stateRef.update(_ + 1)
+                        _      <- reply(seqNr)
+                      } yield false
+
+                    case Cmd.Stop =>
+                      for {
+                        _ <- reply("stopping")
+                      } yield true
+                  }
+                } {
+                  for {
+                    _ <- actorCtx.setReceiveTimeout(Duration.Inf)
+                    _ <- receiveTimeout
+                  } yield false
+                }
+                  .contramapM[Envelope[Any]] { envelope =>
+                    envelope.msg
+                      .castM[F, Cmd]
+                      .map(a => envelope.copy(msg = a))
+                  }
+              }.pure[Resource[F, *]]
+            }
+            .pure[Resource[F, *]]
+        EventSourced(EventSourcedId("id"), value = recoveryStarted).pure[F]
+      }
+
+    def persistentActorOf(
+      actorRef: ActorEffect[F, Any, Any],
+      probe: Probe[F],
+      receiveTimeout: F[Unit]
+    ): F[Unit] = {
+
+      val timeout = 10.seconds
+
+      def withCtx[A: ClassTag](f: ActorCtx[F] => F[A]): F[A] =
+        for {
+          a <- actorRef.ask(Cmd.WithCtx(f), timeout)
+          a <- a
+          a <- a.castM[F, A]
+        } yield a
+
+      for {
+        terminated0 <- probe.watch(actorRef.toUnsafe)
+        dispatcher  <- withCtx(_.executor.pure[F])
+        _           <- Sync[F].delay(dispatcher.toString shouldEqual "Dispatcher[akka.actor.default-dispatcher]")
+        a <- withCtx { ctx =>
+          ActorRefOf
+            .fromActorRefFactory[F](ctx.actorRefFactory)
+            .apply(TestActors.blackholeProps, "child".some)
+            .allocated
+        }
+        (child0, childRelease) = a
+        terminated1           <- probe.watch(child0)
+        children              <- withCtx(_.children)
+        _                     <- Sync[F].delay(children should contain(child0))
+        child                  = withCtx(_.child("child"))
+        child1                <- child
+        _                     <- Sync[F].delay(child1 shouldEqual child0.some)
+        _                     <- childRelease
+        _                     <- terminated1
+        child1                <- child
+        _                     <- Sync[F].delay(child1 shouldEqual none[ActorRef])
+        children              <- withCtx(_.children)
+        _                     <- Sync[F].delay(children should not contain child0)
+        identity              <- actorRef.ask(Identify("id"), timeout).flatten
+        identity              <- identity.castM[F, ActorIdentity]
+        _                     <- withCtx(_.setReceiveTimeout(1.millis))
+        _                     <- receiveTimeout
+        _                     <- Sync[F].delay(identity shouldEqual ActorIdentity("id", actorRef.toUnsafe.some))
+        seqNr                 <- actorRef.ask(Cmd.Inc, timeout).flatten
+        _                      = seqNr shouldEqual 4
+        a                     <- actorRef.ask(Cmd.Stop, timeout).flatten
+        _                      = a shouldEqual "stopping"
+        _                     <- terminated0
+      } yield {}
+    }
+
+    for {
+      receiveTimeout <- Deferred[F, Unit]
+      eventSourcedOf <- eventSourcedOf(receiveTimeout.complete(()).void)
+        .typeless(_.castM[F, State], _.castM[F, Event], _.pure[F])
+        .convert[Any, Any, Receive[F, Envelope[Any], Boolean]](_.pure[F], _.pure[F], _.pure[F], _.pure[F], _.pure[Resource[F, *]])
+        .pure[F]
+      actorRefOf  = ActorRefOf.fromActorRefFactory[F](actorSystem)
+      probe       = Probe.of[F](actorRefOf)
+      actorEffect = EventSourcedActorEffect.of[F](actorRefOf, eventSourcedOf, persistence[F])
+      resources   = (actorEffect, probe).tupled
+      result <- resources.use {
+        case (actorEffect, probe) =>
+          persistentActorOf(actorEffect, probe, receiveTimeout.get)
+      }
+    } yield result
+  }
+
+  private def `recover with empty state`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Any
+
+    val recovery1 = Recovery(toSequenceNr = Int.MaxValue.toLong)
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted[S] { (_, _) =>
+            Recovering
+              .const[S] {
+                Replay.empty[F, E].pure[Resource[F, *]]
+              } {
+                startedDeferred
+                  .complete(())
+                  .toResource
+                  .as(Receive.const[Envelope[C]](false.pure[F]))
+              }
+              .pure[Resource[F, *]]
+          }
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("0"), recovery1, value = recoveryStarted).pure[F]
+      }
+
+    for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.pure[F], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+      _ = actions.reverse shouldEqual List(
+        Action.Created(EventSourcedId("0"), recovery1, PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, None),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recover from snapshot`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Int
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+            Recovering[S] {
+              Replay.empty[F, E].pure[Resource[F, *]]
+            } { (_, journaller, snapshotter) =>
+              val receive = for {
+                seqNr <- journaller.append(Events.of(0)).flatten
+                _     <- snapshotter.save(seqNr, 1).flatten
+                _     <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+              receive.toResource
+            }.pure[Resource[F, *]]
+          }
+
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("1"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    for {
+      saveSnapshot <- actions
+      _ = saveSnapshot shouldEqual List(
+        Action.Created(EventSourcedId("1"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(1),
+        Action.SaveSnapshot(1, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+      recover <- actions
+      _ = recover shouldEqual List(
+        Action.Created(EventSourcedId("1"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(2),
+        Action.SaveSnapshot(2, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.ReceiveAllocated(1L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recover from snapshot with deleted events`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Int
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+            Recovering[S] {
+              Replay.empty[F, E].pure[Resource[F, *]]
+            } { (_, journaller, snapshotter) =>
+              val receive = for {
+                seqNr <- journaller.append(Events.of(0)).flatten
+                _     <- snapshotter.save(seqNr, 1).flatten
+                seqNr <- journaller.append(Events.of(1)).flatten
+                _     <- journaller.deleteTo(seqNr).flatten
+                _     <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+              receive.toResource
+            }.pure[Resource[F, *]]
+          }
+
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("6"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    for {
+      saveSnapshot <- actions
+      _ = saveSnapshot shouldEqual List(
+        Action.Created(EventSourcedId("6"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(1),
+        Action.SaveSnapshot(1, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(2),
+        Action.DeleteEventsTo(2),
+        Action.DeleteEventsToOuter,
+        Action.DeleteEventsToInner,
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+      recover <- actions
+      _ = recover shouldEqual List(
+        Action.Created(EventSourcedId("6"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(3),
+        Action.SaveSnapshot(3, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1L)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(4),
+        Action.DeleteEventsTo(4),
+        Action.DeleteEventsToOuter,
+        Action.DeleteEventsToInner,
+        Action.ReceiveAllocated(2L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recover from events`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Int
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+            Recovering[S] {
+              Replay.empty[F, E].pure[Resource[F, *]]
+            } { (_, journaller, _) =>
+              val receive = for {
+                _ <- journaller.append(Events.batched(Nel.of(0, 1), Nel.of(2))).flatten
+                _ <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+              receive.toResource
+            }.pure[Resource[F, *]]
+          }
+
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("2"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    for {
+      appendEvents <- actions
+      _ = appendEvents shouldEqual List(
+        Action.Created(EventSourcedId("2"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.batched(Nel.of(0, 1), Nel.of(2))),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(3),
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+      recover <- actions
+      _ = recover shouldEqual List(
+        Action.Created(EventSourcedId("2"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.Replayed(0, 1),
+        Action.Replayed(1, 2),
+        Action.Replayed(2, 3),
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.batched(Nel.of(0, 1), Nel.of(2))),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(6),
+        Action.ReceiveAllocated(3L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recover from events with deleted snapshot`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Int
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+            Recovering[S] {
+              Replay.empty[F, E].pure[Resource[F, *]]
+            } { (_, journaller, snapshotter) =>
+              val receive = for {
+                seqNr <- journaller.append(Events.of(0)).flatten
+                _     <- snapshotter.save(seqNr, 1).flatten
+                _     <- journaller.append(Events.of(1)).flatten
+                _     <- snapshotter.delete(seqNr).flatten
+                _     <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+              receive.toResource
+            }.pure[Resource[F, *]]
+          }
+
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("7"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    for {
+      appendEvents <- actions
+      _ = appendEvents shouldEqual List(
+        Action.Created(EventSourcedId("7"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(1),
+        Action.SaveSnapshot(1, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(2),
+        Action.DeleteSnapshot(1),
+        Action.DeleteSnapshotOuter,
+        Action.DeleteSnapshotInner,
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+      recover <- actions
+      _ = recover shouldEqual List(
+        Action.Created(EventSourcedId("7"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.Replayed(0, 1),
+        Action.Replayed(1, 2),
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(3),
+        Action.SaveSnapshot(3, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(4),
+        Action.DeleteSnapshot(3),
+        Action.DeleteSnapshotOuter,
+        Action.DeleteSnapshotInner,
+        Action.ReceiveAllocated(2L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recover from snapshot and events`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Int
+    type C = Any
+    type E = Int
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+            Recovering[S] {
+              Replay.empty[F, E].pure[Resource[F, *]]
+            } { (_, journaller, snapshotter) =>
+              val receive = for {
+                seqNr <- journaller.append(Events.of(0)).flatten
+                _     <- snapshotter.save(seqNr, 1).flatten
+                _     <- journaller.append(Events.of(1)).flatten
+                _     <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+
+              receive.toResource
+            }.pure[Resource[F, *]]
+          }
+
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("3"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    for {
+      write <- actions
+      _ = write shouldEqual List(
+        Action.Created(EventSourcedId("3"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(1),
+        Action.SaveSnapshot(1, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(2),
+        Action.ReceiveAllocated(0L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+      recover <- actions
+      _ = recover shouldEqual List(
+        Action.Created(EventSourcedId("3"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action.ReplayAllocated,
+        Action.Replayed(1, 2),
+        Action.ReplayReleased,
+        Action.AppendEvents(Events.of(0)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(3),
+        Action.SaveSnapshot(3, 1),
+        Action.SaveSnapshotOuter,
+        Action.SaveSnapshotInner,
+        Action.AppendEvents(Events.of(1)),
+        Action.AppendEventsOuter,
+        Action.AppendEventsInner(4),
+        Action.ReceiveAllocated(2L),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `start stops`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Any
+    type C = Any
+    type E = Any
+
+    def eventSourcedOf(
+      delay: F[Unit],
+      stopped: Deferred[F, Unit]
+    ) =
+      EventSourcedOf[F] { actorCtx =>
+        val recoveryStarted =
+          Resource
+            .make(delay productR actorCtx.stop)(_ => stopped.complete(()).void)
+            .as {
+              RecoveryStarted.const {
+                Recovering[S](
+                  Replay
+                    .empty[F, E]
+                    .pure[Resource[F, *]]
+                ) { (_, _, _) =>
+                  Receive
+                    .const[Envelope[C]](false.pure[F])
+                    .pure[Resource[F, *]]
+                }.pure[Resource[F, *]]
+              }
+            }
+        EventSourced(EventSourcedId("10"), value = recoveryStarted).pure[F]
+      }
+
+    for {
+      d0             <- Deferred[F, Unit]
+      d1             <- Deferred[F, Unit]
+      delay           = d0.complete(()) *> d1.get
+      stopped        <- Deferred[F, Unit]
+      actions        <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(delay, stopped)).pure[F]
+      actorEffect     = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      actorEffect    <- actorEffect.allocated.map { case (actorEffect, _) => actorEffect }
+      _ <- Probe.of(actorRefOf).use { probe =>
+        for {
+          _          <- d0.get
+          terminated <- probe.watch(actorEffect.toUnsafe)
+          _          <- Temporal[F].sleep(10.millis)
+          _          <- d1.complete(())
+          _          <- terminated
+        } yield {}
+      }
+      _       <- stopped.get
+      actions <- actions.get
+      _ = actions.reverse shouldEqual List(
+        Action.Created(EventSourcedId("10"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.ReceiveAllocated(0),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recoveryStarted stops`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Any
+    type C = Any
+    type E = Any
+
+    def eventSourcedOf(
+      lock: Deferred[F, Unit],
+      stopped: Deferred[F, Unit]
+    ) =
+      EventSourcedOf[F] { actorCtx =>
+        val recoveryStarted =
+          RecoveryStarted
+            .const {
+              Resource
+                .make(lock.get productR actorCtx.stop)(_ => stopped.complete(()).void)
+                .as {
+                  Recovering.const[S] {
+                    Replay
+                      .empty[F, E]
+                      .pure[Resource[F, *]]
+                  } {
+                    Receive
+                      .const[Envelope[C]](false.pure[F])
+                      .pure[Resource[F, *]]
+                  }
+                }
+            }
+            .pure[Resource[F, *]]
+        EventSourced(EventSourcedId("4"), value = recoveryStarted).pure[F]
+      }
+
+    for {
+      lock           <- Deferred[F, Unit]
+      stopped        <- Deferred[F, Unit]
+      actions        <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(lock, stopped)).pure[F]
+      actorEffect     = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      actorEffect    <- actorEffect.allocated.map { case (actorEffect, _) => actorEffect }
+      _ <- Probe.of(actorRefOf).use { probe =>
+        for {
+          terminated <- probe.watch(actorEffect.toUnsafe)
+          _          <- lock.complete(())
+          _          <- terminated
+        } yield {}
+      }
+      _       <- stopped.get
+      _       <- Async[F].sleep(10.millis) // Make sure all actions are performed first
+      actions <- actions.get
+      _ = actions.reverse shouldEqual List(
+        Action.Created(EventSourcedId("4"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.ReceiveAllocated(0),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `recoveryCompleted stops`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Unit
+    type C = Any
+    type E = Unit
+
+    def eventSourcedOf(
+      lock: Deferred[F, Unit],
+      stopped: Deferred[F, Unit]
+    ) =
+      EventSourcedOf[F] { actorCtx =>
+        val recoveryStarted =
+          RecoveryStarted
+            .const {
+              Recovering
+                .const[S] {
+                  Replay
+                    .empty[F, E]
+                    .pure[Resource[F, *]]
+                } {
+                  Resource
+                    .make(lock.get productR actorCtx.stop)(_ => stopped.complete(()).void)
+                    .as(Receive.const[Envelope[C]](false.pure[F]))
+                }
+                .pure[Resource[F, *]]
+            }
+            .pure[Resource[F, *]]
+        EventSourced(EventSourcedId("5"), value = recoveryStarted).pure[F]
+      }
+
+    for {
+      lock    <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(lock, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect  = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      actorEffect <- actorEffect.allocated.map { case (actorEffect, _) => actorEffect }
+      _ <- Probe.of(actorRefOf).use { probe =>
+        for {
+          terminated <- probe.watch(actorEffect.toUnsafe)
+          _          <- lock.complete(())
+          _          <- terminated
+        } yield {}
+      }
+      _       <- stopped.get
+      _       <- Async[F].sleep(10.millis) // Make sure all actions are performed first
+      actions <- actions.get
+      _ = actions.reverse shouldEqual List(
+        Action.Created(EventSourcedId("5"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased,
+        Action.ReceiveAllocated(0),
+        Action.ReceiveReleased,
+        Action.RecoveryReleased,
+        Action.Released
+      )
+    } yield {}
+  }
+
+  private def `append many`[F[_]: Async: ToFuture: FromFuture: ToTry](
+    actorSystem: ActorSystem
+  ): F[Unit] = {
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Boolean
+    type C = Any
+    type E = SeqNr
+
+    val events = Nel.fromListUnsafe((1L to 1000L).toList)
+
+    def eventSourcedOf(
+      startedDeferred: Deferred[F, Unit],
+      stoppedDeferred: Deferred[F, Unit]
+    ) =
+      EventSourcedOf.const {
+        val recoveryStarted = {
+          val started = RecoveryStarted.const {
+
+            for {
+              stateRef <- Ref[F].of(true).toResource
+            } yield Recovering[S] {
+              Replay.const[E](stateRef.set(false)).pure[Resource[F, *]]
+            } { (_, journaller, _) =>
+              def append: F[Unit] =
+                for {
+                  state <- stateRef.get
+                  result <-
+                    if (state) {
+                      events
+                        .traverse { event =>
+                          journaller.append(Events.of(event))
+                        }
+                        .flatMap(_.foldMapM(_.void))
+                    } else {
+                      ().pure[F]
+                    }
+                } yield result
+
+              val receive = for {
+                _ <- append
+                _ <- startedDeferred.complete(())
+              } yield Receive.const[Envelope[C]](false.pure[F])
+              receive.toResource
+            }
+          }
+          Resource
+            .make(().pure[F])(_ => stoppedDeferred.complete(()).void)
+            .as(started)
+        }
+        EventSourced(EventSourcedId("8"), value = recoveryStarted).pure[F]
+      }
+
+    def actions = for {
+      started <- Deferred[F, Unit]
+      stopped <- Deferred[F, Unit]
+      actions <- Ref[F].of(List.empty[Action[S, C, E]])
+      eventSourcedOf <- InstrumentEventSourced(actions, eventSourcedOf(started, stopped))
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      actorEffect = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      _          <- actorEffect.use(_ => started.get)
+      _          <- stopped.get
+      actions    <- actions.get
+    } yield actions.reverse
+
+    def appends: Nel[Action[S, C, E]] = {
+      val appendEvents: Nel[Action[S, C, E]] = events.flatMap { event =>
+        Nel.of(Action.AppendEvents(Events.of(event)), Action.AppendEventsOuter)
+      }
+      val appendEventsInner: Nel[Action[S, C, E]] = events.map { event =>
+        Action.AppendEventsInner(event)
+      }
+
+      appendEvents ::: appendEventsInner
+    }
+
+    def replayed: Nel[Action[S, C, E]] =
+      events.map(event => Action.Replayed(event, event))
+
+    for {
+      a <- actions
+      _ = a shouldEqual List(
+        Action.Created(EventSourcedId("8"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated,
+        Action.ReplayReleased
+      ) ++
+        appends.toList ++
+        List(Action.ReceiveAllocated(0), Action.ReceiveReleased, Action.RecoveryReleased, Action.Released)
+      a <- actions
+      _ = a shouldEqual List(
+        Action.Created(EventSourcedId("8"), akka.persistence.Recovery(), PluginIds.Empty),
+        Action.Started,
+        Action.RecoveryAllocated(0L, none),
+        Action.ReplayAllocated
+      ) ++
+        replayed.toList ++
+        List(Action.ReplayReleased, Action.ReceiveAllocated(events.last), Action.ReceiveReleased, Action.RecoveryReleased, Action.Released)
+    } yield {}
+  }
+
+  private def setReceiveTimeout[F[_]: Async: ToFuture: FromFuture: ToTry](actorSystem: ActorSystem) = {
+
+    val actorRefOf = ActorRefOf.fromActorRefFactory[F](actorSystem)
+
+    type S = Boolean
+    type C = Any
+    type E = SeqNr
+
+    def eventSourcedOf(timedOut: Deferred[F, Unit]) =
+      EventSourcedOf[F] { actorCtx =>
+        for {
+          _ <- actorCtx.setReceiveTimeout(10.millis)
+        } yield {
+          val recoveryStarted =
+            for {
+              _ <- actorCtx.setReceiveTimeout(10.millis).toResource
+            } yield RecoveryStarted.const {
+              for {
+                _ <- actorCtx.setReceiveTimeout(10.millis).toResource
+              } yield Recovering.const[S] {
+                Replay
+                  .empty[F, E]
+                  .pure[Resource[F, *]]
+              } {
+                for {
+                  _ <- actorCtx.setReceiveTimeout(10.millis).toResource
+                } yield Receive[Envelope[C]] { _ =>
+                  false.pure[F]
+                } {
+                  timedOut.complete(()).as(true)
+                }
+              }
+            }
+          EventSourced(EventSourcedId("9"), value = recoveryStarted)
+        }
+      }
+
+    for {
+      timedOut <- Deferred[F, Unit]
+      eventSourcedOf <- eventSourcedOf(timedOut)
+        .typeless(_.castM[F, S], _.castM[F, E], _.pure[F])
+        .pure[F]
+      result  = EventSourcedActorEffect.of(actorRefOf, eventSourcedOf, persistence[F])
+      result <- result.use(_ => timedOut.get)
+    } yield result
+  }
+}


### PR DESCRIPTION
The PR implements interoperability from Akka snapshot & journal plugins with new `SnapshotStore` & `EventStore` and uses them as persistence in `EventSourcedActorOf` - "persistent" actor that does not rely on Akka Persistence API.

#### Motivation
Get access to persistent actor lifecycle (Akka Persistence impl is private and not extendable) and introduce possibility of back-pressure into events recovery.

#### Implementation details
Akka Persistence plugins can be accessed as actors via restricted to `akka.persistence` package API thus interop implementation located in the same package. Snapshot plugin interop implemented using "ask pattern" due to its simplicity - each operation represented by one command to the plugin actor and one reply command. Journal plugin interop implemented using `LocalActorRef`, inspired by "ask pattern" but supporting multi-command reply.

The reasoning behind `LocalActorRef` is in avoiding overhead of having new actor (per request) and avoiding state management in one long-living actor (that can handle all those commands to snaphotter or journaller actors). Actors are pretty cheap but not fully free and IMO creating new one each time on persisting events will be too much. On other hand managing concurrent requests within one long-living actor (lifespan should be equal to "persistent" actor) also better to be avoided cos concurrent requests must be supported by the persistent plugin anyway and having same logic twice not perfect solution.

As an alternative I'm proposing using `LocalActorRef` - lightweight ActorRef implementation allows aggregating result from multiple responses. Its functionality is limited and should not be used outside of akka-effect thus it marked as `private[akka.persistence]`.

#### How to review
The PR is pretty huge and not easy one for the review, sorry :) 
I propose to start the review from `EventSourcedPersistence` and `EventSourcedActorOf` - the end goal of the change. Then one can go deeper into implementation to `SnapshotStoreInterop` and `EventStoreInterop` - code that communicate with Akka Persistence plugins. After one can continue to `LocalActorRef`, building block of interop implementations and tests.