### PR TITLE
Add timeout for actorRef.tell(GracefulShutdown)

### DIFF
--- a/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterSharding.scala
@@ -68,7 +68,12 @@ object ClusterSharding {
         Sync[F].blocking { actorRef }
       } { actorRef =>
         for {
-          _ <- Sync[F].delay { actorRef.tell(GracefulShutdown, ActorRef.noSender) }
+          _ <- Sync[F].delay {
+              actorRef.tell(GracefulShutdown, ActorRef.noSender)
+            }
+            // TODO: rework or delete the timeout, currently it's needed for debugging
+            .timeoutTo(30.seconds, Async[F].raiseError(new RuntimeException("shutdown of cluster sharding timed out")).void)
+
           _ <- terminated(actorRef).timeout(config.terminateTimeout)
         } yield {}
       }


### PR DESCRIPTION
In our app we have a problem with graceful shutdown getting stuck. We narrowed the shutdown problem to resource release in Akka cluster related code. I suspect there's a race between an internal Evo library shutting down actor system and `actorRef.tell(GracefulShutdown)`.

I'm adding timeout for debugging purposes, we can revert this later