### PR TITLE
do not use loop for event stream materialisation

### DIFF
--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -125,11 +125,12 @@ private[persistence] object LocalActorRef {
         override def !(m: M)(implicit sender: ActorRef): Unit =
           state
             .update { s =>
-              if (receive.isDefinedAt(s.state -> m)) {
+              val p = s.state -> m
+              if (receive.isDefinedAt(p)) {
 
                 for {
                   t <- Clock[F].monotonic(MILLISECONDS)
-                  r <- receive(s.state -> m)
+                  r <- receive(p)
                   s <- r match {
                     case Left(s)  => State(s, t).pure[F]
                     case Right(r) => done(r.asRight).as(s)


### PR DESCRIPTION
Previous implementation rely on `. tailRecM` loop without any async boundaries thus leaded to hight CPU consumption and disruption in cooperative concurrency used by Cats Effect scheduler. The fix reimplement `LocalActorRef` and `Stream` integration by consolidating state inside the actor and using function from `Stream.foldWhileM` only if there's events to process.