### PR TITLE
refactor non-public API to be more aligned with Akka types 

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+OrganizeImports {
+  groups = ["re:javax?\\.", "*", "scala."]
+  groupedImports = AggressiveMerge
+  removeUnused = true
+  coalesceToWildcardImportThreshold = 5
+}
+

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,7 +1,1 @@
-OrganizeImports {
-  groups = ["re:javax?\\.", "*", "scala."]
-  groupedImports = AggressiveMerge
-  removeUnused = true
-  coalesceToWildcardImportThreshold = 5
-}
-
+OrganizeImports.preset = INTELLIJ_2020_3

--- a/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/EngineTestCases.scala
+++ b/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/EngineTestCases.scala
@@ -229,7 +229,6 @@ abstract class EngineTestCases extends AsyncFunSuite with Matchers {
   def `append error prevents further appends`[F[_]: Async: ToFuture: FromFuture]
     : F[Unit] = {
 
-    type S = Unit
     type E = Unit
 
     val error: Throwable = new RuntimeException with NoStackTrace

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -1,6 +1,5 @@
 package akka.persistence
 
-import cats.MonadThrow
 import cats.effect.syntax.all._
 import cats.effect.{Async, Sync}
 import cats.syntax.all._

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -1,13 +1,11 @@
 package akka.persistence
 
-import akka.actor.ActorRef
-import akka.actor.MinimalActorRef
+import akka.actor.{ActorRef, MinimalActorRef}
 import cats.effect.Temporal
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.evolutiongaming.catshelper.CatsHelper.OpsCatsHelper
-import com.evolutiongaming.catshelper.SerialRef
-import com.evolutiongaming.catshelper.ToTry
+import com.evolutiongaming.catshelper.{SerialRef, ToTry}
 
 import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -1,7 +1,5 @@
 package akka.persistence
 
-import java.time.Instant
-
 import akka.persistence.SnapshotSelectionCriteria
 import cats.effect.Sync
 import cats.syntax.all._
@@ -9,6 +7,7 @@ import com.evolutiongaming.akkaeffect.ActorEffect
 import com.evolutiongaming.akkaeffect.persistence.{EventSourcedId, SeqNr, SnapshotStore}
 import com.evolutiongaming.catshelper.{FromFuture, LogOf}
 
+import java.time.Instant
 import scala.concurrent.duration._
 
 object SnapshotStoreInterop {

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -3,7 +3,6 @@ package akka.persistence
 import java.time.Instant
 
 import akka.persistence.SnapshotSelectionCriteria
-import cats.MonadThrow
 import cats.effect.Sync
 import cats.syntax.all._
 import com.evolutiongaming.akkaeffect.ActorEffect
@@ -44,14 +43,13 @@ object SnapshotStoreInterop {
                 snapshot match {
 
                   case Some(offer) =>
-                    val payload   = MonadThrow[F].catchNonFatal(offer.snapshot)
+                    val payload   = offer.snapshot
                     val timestamp = Instant.ofEpochMilli(offer.metadata.timestamp)
                     val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp)
 
                     for {
                       _ <- log.debug(s"recovery: receive offer $offer")
-                      a <- payload
-                    } yield SnapshotStore.Offer(a, metadata).some
+                    } yield SnapshotStore.Offer(payload, metadata).some
 
                   case None => none[SnapshotStore.Offer[Any]].pure[F]
                 }

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -1,27 +1,25 @@
 package akka.persistence
 
+import java.time.Instant
+
 import akka.persistence.SnapshotSelectionCriteria
 import cats.MonadThrow
 import cats.effect.Sync
 import cats.syntax.all._
 import com.evolutiongaming.akkaeffect.ActorEffect
-import com.evolutiongaming.akkaeffect.persistence.EventSourcedId
-import com.evolutiongaming.akkaeffect.persistence.SeqNr
-import com.evolutiongaming.akkaeffect.persistence.SnapshotStore
-import com.evolutiongaming.catshelper.FromFuture
+import com.evolutiongaming.akkaeffect.persistence.{EventSourcedId, SeqNr, SnapshotStore}
+import com.evolutiongaming.catshelper.{FromFuture, LogOf}
 
-import java.time.Instant
 import scala.concurrent.duration._
-import com.evolutiongaming.catshelper.LogOf
 
 object SnapshotStoreInterop {
 
-  def apply[F[_]: Sync: FromFuture: LogOf, A](
+  def apply[F[_]: Sync: FromFuture: LogOf](
     persistence: Persistence,
     timeout: FiniteDuration,
     snapshotPluginId: String,
     eventSourcedId: EventSourcedId
-  ): F[SnapshotStore[F, A]] =
+  ): F[SnapshotStore[F, Any]] =
     for {
       log <- LogOf.log[F, SnapshotStoreInterop.type]
       log <- log.prefixed(eventSourcedId.value).pure[F]
@@ -30,11 +28,11 @@ object SnapshotStoreInterop {
           val actorRef = persistence.snapshotStoreFor(snapshotPluginId)
           ActorEffect.fromActor(actorRef)
         }
-    } yield new SnapshotStore[F, A] {
+    } yield new SnapshotStore[F, Any] {
 
       val persistenceId = eventSourcedId.value
 
-      override def latest: F[Option[SnapshotStore.Offer[A]]] = {
+      override def latest: F[Option[SnapshotStore.Offer[Any]]] = {
         val criteria = SnapshotSelectionCriteria()
         val request  = SnapshotProtocol.LoadSnapshot(persistenceId, criteria, Long.MaxValue)
         val offer = snapshotter
@@ -46,7 +44,7 @@ object SnapshotStoreInterop {
                 snapshot match {
 
                   case Some(offer) =>
-                    val payload   = MonadThrow[F].catchNonFatal(offer.snapshot.asInstanceOf[A])
+                    val payload   = MonadThrow[F].catchNonFatal(offer.snapshot)
                     val timestamp = Instant.ofEpochMilli(offer.metadata.timestamp)
                     val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp)
 
@@ -55,20 +53,20 @@ object SnapshotStoreInterop {
                       a <- payload
                     } yield SnapshotStore.Offer(a, metadata).some
 
-                  case None => none[SnapshotStore.Offer[A]].pure[F]
+                  case None => none[SnapshotStore.Offer[Any]].pure[F]
                 }
 
               case SnapshotProtocol.LoadSnapshotFailed(err) =>
                 for {
                   _ <- log.error(s"loading snapshot failed", err)
-                  a <- err.raiseError[F, Option[SnapshotStore.Offer[A]]]
+                  a <- err.raiseError[F, Option[SnapshotStore.Offer[Any]]]
                 } yield a
             }
           }
         log.debug("recovery: snapshot requested") >> offer
       }
 
-      override def save(seqNr: SeqNr, snapshot: A): F[F[Instant]] = {
+      override def save(seqNr: SeqNr, snapshot: Any): F[F[Instant]] = {
         val metadata = SnapshotMetadata(persistenceId, seqNr)
         val request  = SnapshotProtocol.SaveSnapshot(metadata, snapshot)
         snapshotter

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
@@ -7,14 +7,14 @@ import com.evolutiongaming.catshelper.{FromFuture, ToFuture, LogOf}
 
 object EventSourcedActorEffect {
 
-  def of[F[_]: Async: ToFuture: FromFuture: LogOf](
+  def of[F[_]: Async: ToFuture: FromFuture: LogOf, S, E](
     actorRefOf: ActorRefOf[F],
-    eventSourcedOf: EventSourcedOf[F, EventSourcedActorOf.Lifecycle[F, Any, Any, Any]],
-    persistence: EventSourcedPersistence[F, Any, Any],
+    eventSourcedOf: EventSourcedOf[F, EventSourcedActorOf.Lifecycle[F, S, E, Any]],
+    persistence: EventSourcedPersistence[F, S, E],
     name: Option[String] = None
   ): Resource[F, ActorEffect[F, Any, Any]] = {
 
-    def actor = EventSourcedActorOf.actor[F](eventSourcedOf, persistence)
+    def actor = EventSourcedActorOf.actor[F, S, E](eventSourcedOf, persistence)
 
     val props = Props(actor)
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorEffect.scala
@@ -10,11 +10,11 @@ object EventSourcedActorEffect {
   def of[F[_]: Async: ToFuture: FromFuture: LogOf](
     actorRefOf: ActorRefOf[F],
     eventSourcedOf: EventSourcedOf[F, EventSourcedActorOf.Lifecycle[F, Any, Any, Any]],
-    persistence: EventSourcedPersistence[F],
+    persistence: EventSourcedPersistence[F, Any, Any],
     name: Option[String] = None
   ): Resource[F, ActorEffect[F, Any, Any]] = {
 
-    def actor = EventSourcedActorOf.actor[F, Any, Any, Any](eventSourcedOf, persistence)
+    def actor = EventSourcedActorOf.actor[F](eventSourcedOf, persistence)
 
     val props = Props(actor)
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -1,7 +1,5 @@
 package com.evolutiongaming.akkaeffect.persistence
 
-import java.time.Instant
-
 import akka.actor.Actor
 import akka.persistence.SnapshotSelectionCriteria
 import cats.Monad
@@ -11,6 +9,8 @@ import cats.syntax.all._
 import com.evolutiongaming.akkaeffect._
 import com.evolutiongaming.akkaeffect.persistence.SeqNr
 import com.evolutiongaming.catshelper.{LogOf, ToFuture}
+
+import java.time.Instant
 
 object EventSourcedActorOf {
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -35,7 +35,7 @@ object EventSourcedActorOf {
   /** Factory method aimed to create [[Actor]] capable of handling commands, saving snapshots and producing events. The actor uses Event
     * Sourcing pattern to persist events/snapshots and recover state from them later.
     *
-    * Actor' lifecycle described by type [[Lifecycle]] and consists of multiple phases, such as recovering, receiving messages and
+    * Actor's lifecycle is described by type [[Lifecycle]] and consists of multiple phases, such as recovering, receiving messages and
     * terminating. Recovery happeneds on actor' startup and is about constucting latest actor' state from snapshot and followed events. On
     * receiving phase actor handles incoming commands and chages its state. Each state' change represented by events, that are persisted and
     * later used in recovery phase. Terminating happeneds on actor shutdown (technically it happens as part of [[Actor.postStop]], check

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -36,7 +36,7 @@ object EventSourcedActorOf {
     * Sourcing pattern to persist events/snapshots and recover state from them later.
     *
     * Actor's lifecycle is described by type [[Lifecycle]] and consists of multiple phases, such as recovering, receiving messages and
-    * terminating. Recovery happeneds on actor' startup and is about constucting latest actor' state from snapshot and followed events. On
+    * terminating. Recovery happens on actor's startup and is about constructing latest actor state from snapshot and followed events. On
     * receiving phase actor handles incoming commands and chages its state. Each state' change represented by events, that are persisted and
     * later used in recovery phase. Terminating happeneds on actor shutdown (technically it happens as part of [[Actor.postStop]], check
     * [[ActorOf]] for more details).

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -165,9 +165,7 @@ object EventSourcedActorOf {
                   seqNr1 -> EventStore.Event(event, seqNr1)
               }
             }
-            .flatMap { events =>
-              store.save(events)
-            }
+            .flatMap { store.save }
 
       }
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedPersistence.scala
@@ -1,20 +1,17 @@
 package com.evolutiongaming.akkaeffect.persistence
 
 import akka.actor.ActorSystem
-import akka.persistence.EventStoreInterop
-import akka.persistence.SnapshotStoreInterop
+import akka.persistence.{EventStoreInterop, SnapshotStoreInterop}
 import cats.effect.Async
-import com.evolutiongaming.catshelper.FromFuture
-import com.evolutiongaming.catshelper.LogOf
-import com.evolutiongaming.catshelper.ToTry
+import com.evolutiongaming.catshelper.{FromFuture, LogOf, ToTry}
 
 import scala.concurrent.duration._
 
-trait EventSourcedPersistence[F[_]] {
+trait EventSourcedPersistence[F[_], S, E] {
 
-  def snapshotStore[A](eventSourced: EventSourced[_]): F[SnapshotStore[F, A]]
+  def snapshotStore(eventSourced: EventSourced[_]): F[SnapshotStore[F, S]]
 
-  def eventStore[A](eventSourced: EventSourced[_]): F[EventStore[F, A]]
+  def eventStore(eventSourced: EventSourced[_]): F[EventStore[F, E]]
 
 }
 
@@ -24,18 +21,18 @@ object EventSourcedPersistence {
     system: ActorSystem,
     timeout: FiniteDuration,
     capacity: Int
-  ): EventSourcedPersistence[F] = new EventSourcedPersistence[F] {
+  ): EventSourcedPersistence[F, Any, Any] = new EventSourcedPersistence[F, Any, Any] {
 
     val persistence = akka.persistence.Persistence(system)
 
-    override def snapshotStore[A](eventSourced: EventSourced[_]): F[SnapshotStore[F, A]] = {
+    override def snapshotStore(eventSourced: EventSourced[_]): F[SnapshotStore[F, Any]] = {
       val pluginId = eventSourced.pluginIds.snapshot.getOrElse("")
-      SnapshotStoreInterop[F, A](persistence, timeout, pluginId, eventSourced.eventSourcedId)
+      SnapshotStoreInterop[F](persistence, timeout, pluginId, eventSourced.eventSourcedId)
     }
 
-    override def eventStore[A](eventSourced: EventSourced[_]): F[EventStore[F, A]] = {
+    override def eventStore(eventSourced: EventSourced[_]): F[EventStore[F, Any]] = {
       val pluginId = eventSourced.pluginIds.journal.getOrElse("")
-      EventStoreInterop[F, A](persistence, timeout, capacity, pluginId, eventSourced.eventSourcedId)
+      EventStoreInterop[F](persistence, timeout, capacity, pluginId, eventSourced.eventSourcedId)
     }
   }
 

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -32,7 +32,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, emptyPluginId, persistenceId)
+          store  <- EventStoreInterop[IO](Persistence(system), 1.second, 100, emptyPluginId, persistenceId)
           events <- store.events(SeqNr.Min)
           events <- events.toList
           _       = events shouldEqual List(EventStore.HighestSeqNr(SeqNr.Min))
@@ -59,7 +59,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store  <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           events <- store.events(SeqNr.Min)
           error  <- events.toList.attempt
         } yield error shouldEqual FailingJournal.exception.asLeft[List[EventStore.Event[String]]]
@@ -76,7 +76,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           seqNr <- store.save(Events.of(EventStore.Event("first", 1L), EventStore.Event("second", 2L)))
           error <- seqNr.attempt
         } yield error shouldEqual FailingJournal.exception.asLeft[SeqNr]
@@ -93,7 +93,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store    <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           deleting <- store.deleteTo(SeqNr.Max)
           error    <- deleting.attempt
         } yield error shouldEqual FailingJournal.exception.asLeft[Unit]
@@ -110,7 +110,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store  <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           events <- store.events(SeqNr.Min)
           error  <- events.toList.attempt
         } yield error match {
@@ -129,12 +129,12 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
 
     val timeout  = 1.second
     val capacity = 100
-    val events   = List.tabulate(capacity * 2)(n => EventStore.Event(s"event_$n", n.toLong))
+    val events   = List.tabulate(capacity * 2)(n => EventStore.Event[Any](s"event_$n", n.toLong))
 
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- EventStoreInterop[IO, String](Persistence(system), timeout, capacity, emptyPluginId, persistenceId)
+          store  <- EventStoreInterop[IO](Persistence(system), timeout, capacity, emptyPluginId, persistenceId)
           _      <- store.save(Events.fromList(events).get).flatten
           events <- store.events(SeqNr.Min)
           _      <- IO.sleep(timeout * 2)
@@ -157,7 +157,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           seqNr <- store.save(Events.of(EventStore.Event("first", 1L), EventStore.Event("second", 2L)))
           error <- seqNr.attempt
         } yield error match {
@@ -178,7 +178,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- EventStoreInterop[IO, String](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          store    <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
           deleting <- store.deleteTo(SeqNr.Max)
           error    <- deleting.attempt
         } yield error match {

--- a/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
@@ -32,7 +32,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, emptyPluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, emptyPluginId, persistenceId)
           snapshot <- store.latest
           _         = snapshot shouldEqual none
           _        <- store.save(SeqNr.Min, payload).flatten
@@ -52,7 +52,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, emptyPluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, emptyPluginId, persistenceId)
           _        <- store.save(SeqNr.Min, payload).flatten
           snapshot <- store.latest
           _         = snapshot.get.snapshot should equal(payload)
@@ -73,7 +73,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           error <- store.latest.attempt
           _      = error shouldEqual FailingSnapshotter.exception.asLeft[List[SnapshotStore.Offer[String]]]
         } yield {}
@@ -91,7 +91,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store  <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           saving <- store.save(SeqNr.Min, payload)
           error  <- saving.attempt
           _       = error shouldEqual FailingSnapshotter.exception.asLeft[Instant]
@@ -109,7 +109,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           deleting <- store.delete(SeqNr.Min)
           error    <- deleting.attempt
           _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
@@ -127,7 +127,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           deleting <- store.delete(SnapshotStore.Criteria())
           error    <- deleting.attempt
           _         = error shouldEqual FailingSnapshotter.exception.asLeft[Unit]
@@ -145,7 +145,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use(system =>
         for {
-          store <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           error <- store.latest.attempt
         } yield error match {
           case Left(_: AskTimeoutException) => succeed
@@ -166,7 +166,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store  <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store  <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           saving <- store.save(SeqNr.Min, payload)
           error  <- saving.attempt
         } yield error match {
@@ -187,7 +187,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           deleting <- store.delete(SeqNr.Min)
           error    <- deleting.attempt
         } yield error match {
@@ -208,7 +208,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>
         for {
-          store    <- SnapshotStoreInterop[IO, String](Persistence(system), 1.second, pluginId, persistenceId)
+          store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
           deleting <- store.delete(SnapshotStore.Criteria())
           error    <- deleting.attempt
         } yield error match {

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
@@ -207,7 +207,7 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
         .pure[F]
       actorRefOf  = ActorRefOf.fromActorRefFactory[F](actorSystem)
       probe       = Probe.of[F](actorRefOf)
-      actorEffect = EventSourcedActorEffect.of[F](actorRefOf, eventSourcedOf, persistence[F])
+      actorEffect = EventSourcedActorEffect.of[F, Any, Any](actorRefOf, eventSourcedOf, persistence[F])
       resources   = (actorEffect, probe).tupled
       result <- resources.use {
         case (actorEffect, probe) =>


### PR DESCRIPTION
Akka Persistence API (used by the lib) is not typed and relies on underline persistence plugin implementation. 

I see not much use in having types & casts that will be set to `Any` later, thus dropping types is beneficial due to no casts like `A -> Any -> A`. Code that uses the persistence must by itself somehow interpret persistence plugin data having no type hints (already implemented in `PersistentActor` or its replacements)