### PR TITLE
4.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'sbt'
 
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt ++${{ matrix.scala }} clean check coverage test
 
       - name: test coverage
         if: success()
@@ -33,11 +33,3 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Publish new Release
+
+on:
+  release:
+    types: [published]
+    branches: [master]
+
+jobs:
+  release:
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-release:17", "-Xsource:3", "-deprecation"),
   releaseCrossBuild := true,
   publishTo         := Some(Resolver.evolutionReleases),
+  versionPolicyIntention := Compatibility.BinaryCompatible, // sbt-version-policy
   versionScheme     := Some("semver-spec"),
 
   /*testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oUDNCXEHLOPQRM"))*/

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias("check", "scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias("check", "versionPolicyCheck scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -9,29 +9,27 @@ lazy val commonSettings = Seq(
   scalaVersion         := "2.13.14",
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
   scalacOptions ++= Seq("-release:17", "-Xsource:3", "-deprecation"),
-  releaseCrossBuild := true,
-  publishTo         := Some(Resolver.evolutionReleases),
+  releaseCrossBuild      := true,
+  publishTo              := Some(Resolver.evolutionReleases),
   versionPolicyIntention := Compatibility.BinaryCompatible, // sbt-version-policy
-  versionScheme     := Some("semver-spec"),
+  versionScheme          := Some("semver-spec"),
 
   /*testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oUDNCXEHLOPQRM"))*/
   libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full),
 
   // TODO remove after 4.0.7 is released
   versionPolicyIgnored := Seq(
-    "com.evolutiongaming" %% "random", // removed as was not used
+    "com.evolutiongaming" %% "random",         // removed as was not used
     "com.evolutiongaming" %% "executor-tools", // removed as was not used
-    "com.evolutiongaming" %% "smetrics", // due to update from 2.0.0 to 2.2.0
+    "com.evolutiongaming" %% "smetrics",       // due to update from 2.0.0 to 2.2.0
   ),
-
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
 )
 
 val alias: Seq[sbt.Def.Setting[_]] =
-//  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-  //  addCommandAlias("check", "scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
-    addCommandAlias("check", "versionPolicyCheck") ++
-  addCommandAlias("build", "all compile test")
+  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
+    addCommandAlias("check", "scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias("build", "all compile test")
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -16,13 +16,22 @@ lazy val commonSettings = Seq(
 
   /*testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oUDNCXEHLOPQRM"))*/
   libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full),
+
+  // TODO remove after 4.0.7 is released
+  versionPolicyIgnored := Seq(
+    "com.evolutiongaming" %% "random", // removed as was not used
+    "com.evolutiongaming" %% "executor-tools", // removed as was not used
+    "com.evolutiongaming" %% "smetrics", // due to update from 2.0.0 to 2.2.0
+  ),
+
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
 )
 
 val alias: Seq[sbt.Def.Setting[_]] =
-  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias("check", "scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
-    addCommandAlias("build", "all compile test")
+//  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
+  //  addCommandAlias("check", "scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias("check", "versionPolicyCheck") ++
+  addCommandAlias("build", "all compile test")
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias("check", "versionPolicyCheck scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias("check", "versionPolicyCheck; scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,10 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias("check", "versionPolicyCheck; scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias(
+      "check",
+      "versionPolicyCheck; scalafixEnable; scalafixAll --check; all scalafmtCheckAll scalafmtSbtCheck",
+    ) ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,8 @@ addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.0.2")
 
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
+
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.7-SNAPSHOT"
+ThisBuild / version := "4.0.7"


### PR DESCRIPTION
Binary compatibility check ignored for:
* `random` - removed as was not used
*  `executor-tools` - removed as was not used
* `smetrics` - update from 2.0.0 to 2.2.0 (is it OK?)