### PR TITLE
add field `persisted` into snapshot's metadata

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -49,3 +49,5 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+
+docstrings.style = keep

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,6 @@ lazy val commonSettings = Seq(
   publishTo              := Some(Resolver.evolutionReleases),
   versionPolicyIntention := Compatibility.BinaryCompatible, // sbt-version-policy
   versionScheme          := Some("semver-spec"),
-  versionPolicyCheck     := false,                          // TODO: delete after releasing v5.0.0
   libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full),
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
 )

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val commonSettings = Seq(
   publishTo              := Some(Resolver.evolutionReleases),
   versionPolicyIntention := Compatibility.BinaryCompatible, // sbt-version-policy
   versionScheme          := Some("semver-spec"),
+  versionPolicyCheck     := false,                          // TODO: delete after releasing v5.0.0
   libraryDependencies += compilerPlugin(`kind-projector` cross CrossVersion.full),
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
 )

--- a/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala
+++ b/eventsourcing/src/main/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeper.scala
@@ -71,7 +71,7 @@ object JournalKeeper {
     */
   def of[F[_]: Concurrent: Clock, Sn, St](
     candidate: Candidate[St],
-    snapshotOffer0: Option[SnapshotMetadata],
+    metadata: Option[SnapshotMetadata],
     journaller: Journaller[F],
     snapshotter: Snapshotter[F, Sn],
     snapshotOf: SnapshotOf[F, St, Sn],
@@ -234,7 +234,7 @@ object JournalKeeper {
       timestamp    <- Clock[F].millis
       check         = Check(timestamp)
       save          = Save(check, deletedTo)
-      snapshotOffer = snapshotOffer0.filter(_.persisted)
+      snapshotOffer = metadata.filter(_.persisted)
       (s, f) = {
         if (check(snapshotOffer, timestamp, candidate)) {
           val s = S.saving(none)

--- a/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala
+++ b/eventsourcing/src/test/scala/com/evolutiongaming/akkaeffect/eventsourcing/JournalKeeperTest.scala
@@ -82,7 +82,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(4, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.eventsSaved(5, ().pure[F])
       _             <- journalKeeper.eventsSaved(6, deferred.complete(()).void)
@@ -167,7 +167,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(4, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.eventsSaved(6, deferred.complete(()).void)
       _             <- deferred.get
@@ -185,7 +185,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(2, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.snapshotter.save(3, ().pure[F]).flatten
       _             <- journalKeeper.eventsSaved(4, ().pure[F])
@@ -205,7 +205,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(3, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.snapshotter.delete(2).flatten
       _             <- journalKeeper.eventsSaved(4, ().pure[F])
@@ -225,7 +225,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(3, ().pure[F], metadata.some, config, actions)
       criteria       = SnapshotSelectionCriteria(maxSequenceNr = 3)
       _             <- journalKeeper.snapshotter.delete(criteria).flatten
@@ -252,7 +252,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
     for {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(3, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.eventsSaved(4, ().pure[F])
       _             <- journalKeeper.eventsSaved(6, deferred.complete(()).void)
@@ -276,7 +276,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
       deferred0     <- Deferred[F, Unit]
       deferred1     <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0))
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = Instant.ofEpochMilli(0), persisted = true)
       journalKeeper <- journalKeeperOf(3, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.journaller.deleteTo(3).flatten
       _             <- journalKeeper.eventsSaved(4, ().pure[F])
@@ -366,7 +366,7 @@ class JournalKeeperTest extends AsyncFunSuite with Matchers {
       deferred      <- Deferred[F, Unit]
       actions       <- Actions.of[F, S]
       timestamp     <- Clock[F].instant
-      metadata       = SnapshotMetadata(seqNr = 2, timestamp = timestamp)
+      metadata       = SnapshotMetadata(seqNr = 2, timestamp = timestamp, persisted = true)
       journalKeeper <- journalKeeperOf(2, ().pure[F], metadata.some, config, actions)
       _             <- journalKeeper.eventsSaved(4, ().pure[F])
       _             <- Temporal[F].sleep((config.saveSnapshotCooldown * 1.1).asInstanceOf[FiniteDuration])

--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotStore.scala
@@ -51,7 +51,7 @@ object SnapshotStore {
     def delete(criteria: Criteria): F[F[Unit]]
   }
 
-  final case class Metadata(seqNr: SeqNr, timestamp: Instant)
+  final case class Metadata(seqNr: SeqNr, timestamp: Instant, persisted: Boolean)
 
   final case class Offer[A](snapshot: A, metadata: Metadata)
 

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration.*
   */
 private[persistence] trait LocalActorRef[F[_], R] {
 
-  /** Not actual [[ActorRef]]! It is not serialisable, thus can not be passed over network. Under the hood it implements
+  /** Not actual [[ActorRef]]! It is not serializable, thus can not be passed over network. Under the hood it implements
     * [[ActorRef]] trait by providing function `!` that updates internal state using provided function `receive`. Please
     * check [[LocalActorRef.apply]] docs
     */
@@ -87,7 +87,7 @@ private[persistence] object LocalActorRef {
          * @param delay
          *   time before next timeout
          * @return
-         *   exid or continue loop
+         *   exit or continue loop
          */
         def failOnTimeout(delay: Delay): F[Either[Delay, Unit]] =
           for {

--- a/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/SnapshotStoreInterop.scala
@@ -44,7 +44,7 @@ object SnapshotStoreInterop {
                   case Some(offer) =>
                     val payload   = offer.snapshot
                     val timestamp = Instant.ofEpochMilli(offer.metadata.timestamp)
-                    val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp)
+                    val metadata  = SnapshotStore.Metadata(offer.metadata.sequenceNr, timestamp, persisted = true)
 
                     for {
                       _ <- log.debug(s"recovery: receive offer $offer")

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -131,7 +131,7 @@ object EventSourcedActorOf {
 
     def asOffer: SnapshotOffer[S] =
       SnapshotOffer(
-        SnapshotMetadata(snapshot.metadata.seqNr, snapshot.metadata.timestamp),
+        SnapshotMetadata(snapshot.metadata.seqNr, snapshot.metadata.timestamp, snapshot.metadata.persisted),
         snapshot.snapshot,
       )
 

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotMetadata.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/SnapshotMetadata.scala
@@ -5,12 +5,16 @@ import java.time.Instant
 /** @see
   *   [[akka.persistence.SnapshotMetadata]]
   */
-final case class SnapshotMetadata(seqNr: SeqNr, timestamp: Instant)
+final case class SnapshotMetadata(seqNr: SeqNr, timestamp: Instant, persisted: Boolean)
 
 object SnapshotMetadata {
 
-  val Empty: SnapshotMetadata = SnapshotMetadata(seqNr = 1, timestamp = Instant.ofEpochMilli(0))
+  val Empty: SnapshotMetadata = SnapshotMetadata(seqNr = 1, timestamp = Instant.ofEpochMilli(0), persisted = true)
 
   def apply(metadata: akka.persistence.SnapshotMetadata): SnapshotMetadata =
-    SnapshotMetadata(seqNr = metadata.sequenceNr, timestamp = Instant.ofEpochMilli(metadata.timestamp))
+    SnapshotMetadata(
+      seqNr = metadata.sequenceNr,
+      timestamp = Instant.ofEpochMilli(metadata.timestamp),
+      persisted = true,
+    )
 }

--- a/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/SnapshotStoreInteropTest.scala
@@ -52,7 +52,9 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, emptyPluginId, persistenceId)
           _        <- store.save(SeqNr.Min, payload).flatten
           snapshot <- store.latest
-          _         = snapshot.get.snapshot should equal(payload)
+          offer    <- snapshot.liftTo[IO](new IllegalStateException)
+          _         = offer.snapshot should equal(payload)
+          _         = offer.metadata.persisted shouldBe true
           _        <- store.delete(SeqNr.Min).flatten
           snapshot <- store.latest
           _         = snapshot shouldEqual none

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOfTest.scala
@@ -355,7 +355,8 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("1"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.ReplayAllocated,
         Action.ReplayReleased,
         Action.AppendEvents(Events.of(0L)),
@@ -451,7 +452,8 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("6"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.ReplayAllocated,
         Action.ReplayReleased,
         Action.AppendEvents(Events.of(0L)),
@@ -738,7 +740,8 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("3"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.ReplayAllocated,
         Action.Replayed(1, 2),
         Action.ReplayReleased,

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOfTest.scala
@@ -345,7 +345,8 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("1"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.AppendEvents(Events.of(0L)),
         Action.AppendEventsOuter,
         Action.AppendEventsInner(2),
@@ -437,7 +438,8 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("6"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.AppendEvents(Events.of(0L)),
         Action.AppendEventsOuter,
         Action.AppendEventsInner(3),
@@ -716,7 +718,8 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
       _ = recover shouldEqual List(
         Action.Created(EventSourcedId("3"), akka.persistence.Recovery(), PluginIds.Empty),
         Action.Started,
-        Action.RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0)), 1).some),
+        Action
+          .RecoveryAllocated(1L, SnapshotOffer(SnapshotMetadata(1, Instant.ofEpochMilli(0), persisted = true), 1).some),
         Action.ReplayAllocated,
         Action.Replayed(1, 2),
         Action.ReplayReleased,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.1.4-SNAPSHOT"
+ThisBuild / version := "5.0.0"


### PR DESCRIPTION
This is breaking change due to binary incompatibility after after adding new fields into existing case classes. Next release must be of version `5.0.0`