### PR TITLE
SHRIKE-54: expose notion of `persistent` snapshot in backward-compatible way

### DIFF
--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -116,7 +116,8 @@ object EventSourcedActorOf {
 
           _          <- log.debug(s"recovery completed with seqNr $seqNr")
           journaller <- eventStore.asJournaller(actorCtx, seqNr).toResource
-          receive    <- recovering.completed(seqNr, journaller, snapshotStore.asSnapshotter)
+          context     = Recovering.RecoveryContext(seqNr, journaller, snapshotStore.asSnapshotter)
+          receive    <- recovering.completed(context)
         } yield receive
 
         receive.onError {

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventSourcedActorOf.scala
@@ -125,7 +125,7 @@ object EventSourcedActorOf {
       }
   }
 
-  implicit final private class SnapshotOps[S](val snapshot: SnapshotStore.Offer[S]) extends AnyVal {
+  implicit final private[evolutiongaming] class SnapshotOps[S](val snapshot: SnapshotStore.Offer[S]) extends AnyVal {
 
     def asOffer: SnapshotOffer[S] =
       SnapshotOffer(
@@ -135,7 +135,8 @@ object EventSourcedActorOf {
 
   }
 
-  implicit final private class SnapshotStoreOps[F[_], A](val store: SnapshotStore[F, A]) extends AnyVal {
+  implicit final private[evolutiongaming] class SnapshotStoreOps[F[_], A](val store: SnapshotStore[F, A])
+      extends AnyVal {
 
     def asSnapshotter: Snapshotter[F, A] = new Snapshotter[F, A] {
 
@@ -154,7 +155,7 @@ object EventSourcedActorOf {
     }
   }
 
-  implicit final private class EventStoreOps[F[_], E](val store: EventStore[F, E]) extends AnyVal {
+  implicit final private[evolutiongaming] class EventStoreOps[F[_], E](val store: EventStore[F, E]) extends AnyVal {
 
     def asJournaller(actorCtx: ActorCtx[F], seqNr: SeqNr)(implicit F: Concurrent[F], log: Log[F]): F[Journaller[F, E]] =
       for {

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Recovering.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Recovering.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.effect.Resource
 import cats.implicits.catsSyntaxApplicativeId
 import com.evolutiongaming.akkaeffect.{Envelope, Receive}
+
 import scala.annotation.nowarn
 
 /** Describes "Recovery" phase

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Recovering.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Recovering.scala
@@ -30,9 +30,26 @@ trait Recovering[F[_], S, E, +A] {
     journaller: Journaller[F, E],
     snapshotter: Snapshotter[F, S],
   ): Resource[F, A]
+
+  /** Called when recovery completed, resource will be released upon actor termination
+    *
+    * @see
+    *   [[akka.persistence.RecoveryCompleted]]
+    */
+  def completed(context: Recovering.RecoveryContext[F, S, E]): Resource[F, A] =
+    completed(context.seqNr, context.journaller, context.snapshotter)
 }
 
 object Recovering {
+
+  /** Context containing information about recovery and provides access to journaller and snapshotter
+    */
+  trait RecoveryContext[F[_], S, E] {
+    def seqNr: SeqNr
+    def journaller: Journaller[F, E]
+    def snapshotter: Snapshotter[F, S]
+    def recoveredFromPersistence: Boolean
+  }
 
   def apply[S]: Apply[S] = new Apply[S]
 

--- a/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/InstrumentEventSourced.scala
+++ b/persistence/src/test/scala/com/evolutiongaming/akkaeffect/persistence/InstrumentEventSourced.scala
@@ -111,7 +111,8 @@ object InstrumentEventSourced {
             }
 
             for {
-              receive <- recovering.completed(seqNr, journaller1, snapshotter1)
+              context <- Recovering.RecoveryContext(seqNr, journaller1, snapshotter1).pure[Resource[F, *]]
+              receive <- recovering.completed(context)
               _       <- resource(Action.ReceiveAllocated(seqNr), Action.ReceiveReleased)
             } yield Receive[Envelope[C]] { envelope =>
               for {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.1.5-SNAPSHOT"
+ThisBuild / version := "4.2.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.2.0"
+ThisBuild / version := "4.1.5"


### PR DESCRIPTION
Done as backward-compatible alternative to https://github.com/evolution-gaming/akka-effect/pull/318

The PR should be merged after https://github.com/evolution-gaming/akka-effect/pull/319 to avoid breaking changes & major version bump.