### PR TITLE
Do not consume events lazy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val commonSettings = Seq(
   startYear            := Some(2019),
   scalaVersion         := "2.13.14",
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
+  Compile / doc / scalacOptions -= "-Xfatal-warnings",
   scalacOptions ++= Seq("-release:17", "-Xsource:3", "-deprecation"),
   releaseCrossBuild      := true,
   publishTo              := Some(Resolver.evolutionReleases),

--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,7 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias(
-      "check",
-      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
-    ) ++
+    addCommandAlias("check", "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck") ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
     addCommandAlias(
       "check",
-      "all versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
+      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
     ) ++
     addCommandAlias("build", "all compile test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
     addCommandAlias(
       "check",
-      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
+      "all versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
     ) ++
     addCommandAlias("build", "all compile test")
 

--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
@@ -60,7 +60,7 @@ object EventStore {
     * @param event
     *   domain event of type [[A]]
     * @param seqNr
-    *   assosiated with event sequence number
+    *   associated with event sequence number
     */
   final case class Event[A](event: A, seqNr: SeqNr) extends Persisted[A]
 

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -143,8 +143,13 @@ object EventStoreInterop {
                       consumer <- state.consumer
                       consumer <- consumer.onEvent(event(persisted))
                     } yield consumer
-                    val state1 = State.Consuming(consumer): State
-                    state1.asLeft[Consumer].pure[F]
+                    for {
+                      fiber <- consumer.start
+                    } yield {
+                      val joined = fiber.join.flatMap(_.embedError)
+                      val state1 = State.Consuming(joined): State
+                      state1.asLeft[Consumer]
+                    }
 
                   case JournalProtocol.RecoverySuccess(seqNr) =>
                     for {

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -99,10 +99,10 @@ private[persistence] object LocalActorRef {
 
         type Delay = FiniteDuration
 
-        /** If state was not updated for more than [[#timeout]] - completes [[#defer]] with failed result and exits
-          * tailRecM loop.
+        /** If state was not updated for more than `timeout` - completes `defer` with failed result and exits tailRecM
+          * loop.
           *
-          * Otherwise calculate [[#delay]] till next timeout and continue loop.
+          * Otherwise calculate `delay` till next timeout and continue loop.
           *
           * @param delay
           *   time before next timeout

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -99,10 +99,10 @@ private[persistence] object LocalActorRef {
 
         type Delay = FiniteDuration
 
-        /** If state was not updated for more than `timeout` - completes `defer` with failed result and exits tailRecM
-          * loop.
+        /** If state was not updated for more than [[#timeout]] - completes [[#defer]] with failed result and exits
+          * tailRecM loop.
           *
-          * Otherwise calculate `delay` till next timeout and continue loop.
+          * Otherwise calculate [[#delay]] till next timeout and continue loop.
           *
           * @param delay
           *   time before next timeout

--- a/persistence/src/test/resources/test.conf
+++ b/persistence/src/test/resources/test.conf
@@ -24,6 +24,12 @@ infinite-journal {
   plugin-dispatcher = "akka.actor.default-dispatcher"
 }
 
+delayed-journal {
+  class = "akka.persistence.DelayedPersistence"
+  plugin-dispatcher = "akka.actor.default-dispatcher"
+  replay-filter.mode = off // do not batch replayed messages
+}
+
 failing-snapshot {
   class = "akka.persistence.FailingSnapshotter"
   plugin-dispatcher = "akka.actor.default-dispatcher"

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -1,16 +1,18 @@
 package akka.persistence
 
 import akka.persistence.journal.AsyncWriteJournal
-import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import cats.effect.{Deferred, IO}
 import cats.syntax.all.*
 import com.evolutiongaming.akkaeffect.persistence.{EventSourcedId, EventStore, Events, SeqNr}
 import com.evolutiongaming.akkaeffect.testkit.TestActorSystem
+import com.evolutiongaming.akkaeffect.util.AtomicRef
 import com.evolutiongaming.catshelper.LogOf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.util.concurrent.TimeoutException
+import javax.naming.OperationNotSupportedException
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.concurrent.duration.*
@@ -50,6 +52,63 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
       }
 
     io.unsafeRunSync()
+  }
+
+  test("journal: start processing events before final event received") {
+
+    val pluginId      = "delayed-journal"
+    val persistenceId = EventSourcedId("#21")
+
+    val io = TestActorSystem[IO]("testing", none)
+      .use { system =>
+        val n        = 1000L
+        val maxSeqNr = n - 1 // SeqNr starts from 0
+
+        def events: List[EventStore.Event[Any]] =
+          List.range(0, n).map(n => EventStore.Event(s"event_$n", n.toLong))
+
+        for {
+          // persist n events
+          store <- EventStoreInterop[IO](Persistence(system), 1.second, 100, pluginId, persistenceId)
+          seqNr <- store.save(Events.fromList(events).get).flatten
+          _      = seqNr shouldEqual maxSeqNr
+
+          // recover events if persistence delayed for any event
+          stream <- store.events(SeqNr.Min)
+          error  <- stream.toList.attempt
+          _       = error shouldBe a[Left[TimeoutException, _]]
+
+          // recover events if persistence delayed after recovering half of events
+          half    = n.toInt / 2
+          quarter = n.toInt / 4
+          permit <- DelayedPersistence.permit(quarter)
+          stream <- store.events(SeqNr.Min)
+          done   <- IO.deferred[Unit]
+          _ <- stream
+            .foldWhileM(1L) {
+              case (`half`, _)    => done.complete {} as ().asRight[Long]
+              case (`quarter`, _) => permit.inc(quarter) as (quarter + 1L).asLeft[Unit]
+              case (n, _)         => (n + 1).asLeft[Unit].pure[IO]
+            }
+            .flatTap { _ =>
+              IO.delay(fail("events stream should never complete due to permit limitation"))
+            }
+            .start
+
+          // the timeout used only to fail the test if events cannot be consumed
+          // its value should not corelate with `EventStoreInterop` timeout
+          _ <- done.get.timeoutTo(500.millis, IO.delay(fail("not all available events were consumed")))
+
+          // recover events if persistence does not delayed
+          _      <- DelayedPersistence.permit(n.toInt)
+          stream <- store.events(SeqNr.Min)
+          events <- stream.toList
+          _       = events.length shouldBe n + 1 // + HighestSeqNr event
+        } yield {}
+      }
+
+    io.unsafeRunSync()
+
   }
 
   test("journal: fail loading events") {
@@ -225,5 +284,123 @@ class InfiniteJournal extends AsyncWriteJournal {
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = Future.never
 
   override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = Future.never
+
+}
+
+object DelayedPersistence {
+
+  trait Permit {
+    def get: IO[Unit]
+    def inc(i: Int = 1): IO[Unit]
+  }
+  object Permit {
+
+    sealed trait Type
+    object Issued                                  extends Type
+    case class Awaiting(await: Deferred[IO, Unit]) extends Type
+
+    val never = unsafe(0)
+
+    def unsafe(n: Int): Permit = new Permit {
+
+      private val permits = IO.ref(List.fill[Type](n)(Issued)).unsafeRunSync()
+
+      private val delay = IO.sleep(1.millisecond)
+
+      def get: IO[Unit] =
+        permits.flatModify {
+
+          case Nil =>
+            val await = IO.deferred[Unit].unsafeRunSync()
+            List(Awaiting(await)) -> await.get
+
+          case Issued :: t =>
+            t -> IO.unit
+
+          case Awaiting(await) :: t =>
+            t -> await.get
+
+        }
+
+      def inc(i: Int): IO[Unit] =
+        permits.flatModify {
+          case Nil                  => List.fill(i)(Issued)           -> delay
+          case issued @ Issued :: _ => issued ++ List.fill(i)(Issued) -> delay
+          case Awaiting(await) :: t => t -> await.complete {} *> { if (i > 1) inc(i - 1) else delay }
+        }
+
+    }
+  }
+
+  private val state = IO.ref(Permit.never).unsafeRunSync()
+
+  def permit(n: Int = 1): IO[Permit] = {
+    val p = Permit.unsafe(n)
+    state.set(p).as(p)
+  }
+
+  def permit: IO[Permit] = state.getAndSet(Permit.never)
+
+}
+
+class DelayedPersistence extends AsyncWriteJournal {
+
+  import DelayedPersistence.*
+  import scala.concurrent.ExecutionContext.Implicits.{global => ec}
+
+  private val state = AtomicRef[Map[String, Vector[PersistentRepr]]](Map.empty)
+
+  override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
+    recoveryCallback: PersistentRepr => Unit,
+  ): Future[Unit] = {
+    val events =
+      IO.delay {
+        state
+          .get()
+          .getOrElse(persistenceId, Vector.empty)
+          .filter { event =>
+            event.sequenceNr >= fromSequenceNr && event.sequenceNr <= toSequenceNr
+          }
+      }
+
+    val io = for {
+      permit <- permit
+      events <- events
+      _ <- events.traverse { event =>
+        for {
+          _ <- permit.get
+          _ <- IO.delay(recoveryCallback(event))
+        } yield ()
+      }
+    } yield {}
+
+    io.void.unsafeToFuture()
+  }
+
+  override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
+    Future {
+      state
+        .get()
+        .getOrElse(persistenceId, Vector.empty)
+        .foldLeft(fromSequenceNr) { (max, event) =>
+          if (event.sequenceNr > max) event.sequenceNr else max
+        }
+    }
+
+  override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] =
+    Future {
+      messages.foreach { atomicWrite =>
+        val events        = atomicWrite.payload
+        val persistenceId = atomicWrite.persistenceId
+        state.update { state =>
+          val current = state.getOrElse(persistenceId, Vector.empty)
+          state.updated(persistenceId, current ++ events)
+        }
+      }
+      Seq.empty[Try[Unit]]
+    }
+
+  override def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] =
+    Future.failed(new OperationNotSupportedException("deleteMessagesTo is not supported in the test"))
 
 }


### PR DESCRIPTION
`EventStoreInterop` is an implementation of event store on top of Akka Persistence plugins, i.e. logic that implements `EventStore` trait and uses `JournalProtocol.XXX` classes to communicate with plugin actor.

Recovering events require managing actor's state while the recovery happening thus here's the state:
```
        sealed trait State
        object State {

          object Empty                                                                   extends State
          case class Buffering(events: Vector[EventStore.Event[Any]])                    extends State
          case class Consuming(consumer: F[Consumer])                                    extends State
          case class Finishing(events: Vector[EventStore.Event[Any]], finalSeqNr: SeqNr) extends State

        }
```
where `Consuming` represents presence on the consumer, i.e. thing that calls user-defined stream callback. On each new event consumer will handler it lazily by adding handle action on top of action's stack:
```
              case state: State.Consuming =>
                message match {
                  case JournalProtocol.ReplayedMessage(persisted) =>
                    val consumer = for {
                      consumer <- state.consumer
                      consumer <- consumer.onEvent(event(persisted))
                    } yield consumer
                    val state1 = State.Consuming(consumer): State
                    state1.asLeft[Consumer].pure[F]
```
effectively postponing `consumer.onEvent(event(persisted))` until whole stream is consumed and buffered in memory. This can be improved by pushing events into the consumer immediately on arrival (if the consumer is available) or still processing them asynchronously (but without spawning fibers on each event)  