### PR TITLE
reproduce bug: events can be consumed only after last event received

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,10 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias("check", "all versionPolicyCheck") ++
+    addCommandAlias(
+      "check",
+      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
+    ) ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,12 @@ lazy val commonSettings = Seq(
 )
 
 val alias: Seq[sbt.Def.Setting[_]] =
-  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
+  addCommandAlias("fmt", "clean; scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
     addCommandAlias(
       "check",
-      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
+      "clean; all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
     ) ++
-    addCommandAlias("build", "all compile test")
+    addCommandAlias("build", "clean; all compile test")
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,9 @@ lazy val commonSettings = Seq(
 )
 
 val alias: Seq[sbt.Def.Setting[_]] =
-  addCommandAlias("fmt", "clean; scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias(
-      "check",
-      "clean; all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
-    ) ++
-    addCommandAlias("build", "clean; all compile test")
+  addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
+    addCommandAlias("check", "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck") ++
+    addCommandAlias("build", "all compile test")
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -19,10 +19,7 @@ lazy val commonSettings = Seq(
 
 val alias: Seq[sbt.Def.Setting[_]] =
   addCommandAlias("fmt", "scalafixEnable; scalafixAll; all scalafmtAll scalafmtSbt") ++
-    addCommandAlias(
-      "check",
-      "all Compile/doc versionPolicyCheck scalafmtCheckAll scalafmtSbtCheck; scalafixEnable; scalafixAll --check",
-    ) ++
+    addCommandAlias("check", "all versionPolicyCheck") ++
     addCommandAlias("build", "all compile test")
 
 lazy val root = project

--- a/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
+++ b/persistence-api/src/main/scala/com/evolutiongaming/akkaeffect/persistence/EventStore.scala
@@ -60,7 +60,7 @@ object EventStore {
     * @param event
     *   domain event of type [[A]]
     * @param seqNr
-    *   assosiated with event sequence number
+    *   associated with event sequence number
     */
   final case class Event[A](event: A, seqNr: SeqNr) extends Persisted[A]
 

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -196,7 +196,7 @@ object EventStoreInterop {
             }
 
             for {
-              _ <- log.debug(s"recovery: events stream materialisation started")
+              _ <- log.debug(s"recovery: events stream materialization started")
               _ <- Sync[F].delay(actor.ref ! new TheConsumer(l.asLeft[R]))
               c <- actor.res
             } yield c.asInstanceOf[TheConsumer].state

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -143,13 +143,6 @@ object EventStoreInterop {
                       consumer <- state.consumer
                       consumer <- consumer.onEvent(event(persisted))
                     } yield consumer
-                    // for {
-                    //   fiber <- consumer.start
-                    // } yield {
-                    //   val joined = fiber.join.flatMap(_.embedError)
-                    //   val state1 = State.Consuming(joined): State
-                    //   state1.asLeft[Consumer]
-                    // }
                     val state1 = State.Consuming(consumer): State
                     state1.asLeft[Consumer].pure[F]
 

--- a/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
+++ b/persistence/src/main/scala/akka/persistence/EventStoreInterop.scala
@@ -143,6 +143,13 @@ object EventStoreInterop {
                       consumer <- state.consumer
                       consumer <- consumer.onEvent(event(persisted))
                     } yield consumer
+                    // for {
+                    //   fiber <- consumer.start
+                    // } yield {
+                    //   val joined = fiber.join.flatMap(_.embedError)
+                    //   val state1 = State.Consuming(joined): State
+                    //   state1.asLeft[Consumer]
+                    // }
                     val state1 = State.Consuming(consumer): State
                     state1.asLeft[Consumer].pure[F]
 

--- a/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/akka/persistence/LocalActorRef.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration.*
   */
 private[persistence] trait LocalActorRef[F[_], R] {
 
-  /** Not actual [[ActorRef]]! It is not serialisable, thus can not be passed over network. Under the hood it implements
+  /** Not actual [[ActorRef]]! It is not serializable, thus can not be passed over network. Under the hood it implements
     * [[ActorRef]] trait by providing function `!` that updates internal state using provided function `receive`. Please
     * check [[LocalActorRef.apply]] docs
     */

--- a/persistence/src/test/resources/test.conf
+++ b/persistence/src/test/resources/test.conf
@@ -24,6 +24,12 @@ infinite-journal {
   plugin-dispatcher = "akka.actor.default-dispatcher"
 }
 
+delayed-journal {
+  class = "akka.persistence.DelayedPersistence"
+  plugin-dispatcher = "akka.actor.default-dispatcher"
+  replay-filter.mode = off // do not batch replayed messages
+}
+
 failing-snapshot {
   class = "akka.persistence.FailingSnapshotter"
   plugin-dispatcher = "akka.actor.default-dispatcher"

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -28,7 +28,6 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
   test("journal: replay (nothing), save, replay, delete, replay") {
 
     val persistenceId = EventSourcedId("#10")
-    
 
     val io = TestActorSystem[IO]("testing", none)
       .use { system =>

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicInteger
 import javax.naming.OperationNotSupportedException
 import scala.collection.immutable.Seq
 import scala.concurrent.Future

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -88,7 +88,7 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
             case (n, _)  => (n - 1).asLeft[Unit].pure[IO]
           }
           _ <- test.start
-          _ <- done.get.timeout(1.second)
+          _ <- done.get.timeout(500.millis)
 
           // recover events if persistence does not delayed
           _      <- DelayedPersistence.permit(n.toInt)

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -87,7 +87,9 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
           running <- IO.deferred[Unit]
           consume = stream.foldWhileM(half) {
             case (1L, _) => done.complete {}.as(().asRight[Long])
-            case (n, _)  => running.complete {} as (n - 1).asLeft[Unit]
+            case (n, _) =>
+              println(s">>>>> n = $n")
+              running.complete {} as (n - 1).asLeft[Unit]
           }
           _ <- consume.start
           _ <- running.get

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -84,8 +84,8 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
           stream <- store.events(SeqNr.Min)
           done   <- IO.deferred[Unit]
           test = stream.foldWhileM(half) {
-            case (1L, e) => done.complete {}.as(().asRight[Long])
-            case (n, e)  => (n - 1).asLeft[Unit].pure[IO]
+            case (1L, _) => done.complete {}.as(().asRight[Long])
+            case (n, _)  => (n - 1).asLeft[Unit].pure[IO]
           }
           _ <- test.start
           _ <- done.get.timeout(1.second)
@@ -312,9 +312,7 @@ class DelayedPersistence extends AsyncWriteJournal {
   import DelayedPersistence.*
   import scala.concurrent.ExecutionContext.Implicits.{global => ec}
 
-  private val timeout = 1.minute
-  private val delay   = 10.millis
-  private val state   = AtomicRef[Map[String, Vector[PersistentRepr]]](Map.empty)
+  private val state = AtomicRef[Map[String, Vector[PersistentRepr]]](Map.empty)
 
   override def asyncReplayMessages(persistenceId: String, fromSequenceNr: Long, toSequenceNr: Long, max: Long)(
     recoveryCallback: PersistentRepr => Unit,

--- a/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
+++ b/persistence/src/test/scala/akka/persistence/EventStoreInteropTest.scala
@@ -88,6 +88,8 @@ class EventStoreInteropTest extends AnyFunSuite with Matchers {
             case (n, _)  => (n - 1).asLeft[Unit].pure[IO]
           }
           _ <- test.start
+          // the timeout used only to fail the test if events cannot be consumed
+          // its value should not corelate with `EventStoreInterop` timeout
           _ <- done.get.timeout(500.millis)
 
           // recover events if persistence does not delayed


### PR DESCRIPTION
One test must fail, that's the essence of this PR:
```
journal: start processing events before final event received *** FAILED ***
```