### PR TITLE
Update sbt to 2.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,19 @@ jobs:
           - 3.3.8
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # sbt-dynver needs tags, otherwise the version is 0.0.0, versionPolicyCheck has no
           # previous version to compare against, and the binary compatibility check does nothing.
           fetch-depth: 0
 
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
 
       - name: setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: 'oracle'
+          distribution: 'temurin'
           cache: 'sbt'
 
       - name: setup SBT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,24 @@ jobs:
       - name: setup SBT
         uses: sbt/setup-sbt@v1
 
-      - name: Check code formatting
-        run: sbt check
-
+      # The coverage build must run before anything else compiles: sbt 2 does not key its compile
+      # cache on scoverage's instrumentation, so a plain compile done first gets reused here and
+      # silently yields an empty coverage report.
       - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt "++${{ matrix.scala }}; clean; coverage; testFull; coverageAggregate"
+
+      - name: check code ${{ matrix.scala }}
+        run: sbt "++${{ matrix.scala }}; check"
+
+      - name: locate coverage report
+        id: coverage
+        if: success()
+        run: echo "file=$(find . -path '*/coverage-report/cobertura.xml' | head -1)" >> "$GITHUB_OUTPUT"
 
       - name: test coverage
         if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: ${{ steps.coverage.outputs.file }}
+          format: cobertura
+          flag-name: Scala ${{ matrix.scala }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
 
       - name: setup SBT
         uses: sbt/setup-sbt@v1
+        with:
+          # sbt 2's disk cache is restored across runs and is not keyed on scoverage's
+          # instrumentation, so a cached compile would be reused without re-emitting coverage data.
+          disk-cache: false
 
-      # The coverage build must run before anything else compiles: sbt 2 does not key its compile
-      # cache on scoverage's instrumentation, so a plain compile done first gets reused here and
-      # silently yields an empty coverage report.
+      # The coverage build must also run before anything else compiles, for the same reason: a plain
+      # compile done first gets reused here and silently yields an empty coverage report.
       - name: build ${{ matrix.scala }}
         run: sbt "++${{ matrix.scala }}; clean; coverage; testFull; coverageAggregate"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # sbt-dynver needs tags, otherwise the version is 0.0.0, versionPolicyCheck has no
+          # previous version to compare against, and the binary compatibility check does nothing.
+          fetch-depth: 0
 
       - uses: coursier/cache-action@v6
 

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorCtx.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorCtx.scala
@@ -86,9 +86,9 @@ object ActorCtx {
 
       def actorRefFactory: ActorRefFactory = actorContext
 
-      def watch[A](actorRef: ActorRef, msg: A) = act { actorContext.watchWith(actorRef, msg); () }
+      def watch[A](actorRef: ActorRef, msg: A) = act { val _ = actorContext.watchWith(actorRef, msg) }
 
-      def unwatch(actorRef: ActorRef) = act { actorContext.unwatch(actorRef); () }
+      def unwatch(actorRef: ActorRef) = act { val _ = actorContext.unwatch(actorRef) }
 
       def stop = act(actorContext.stop(actorContext.self))
     }
@@ -112,9 +112,9 @@ object ActorCtx {
 
       def actorRefFactory: ActorRefFactory = actorContext
 
-      def watch[A](actorRef: ActorRef, msg: A) = Sync[F].delay { actorContext.watchWith(actorRef, msg); () }
+      def watch[A](actorRef: ActorRef, msg: A) = Sync[F].delay { val _ = actorContext.watchWith(actorRef, msg) }
 
-      def unwatch(actorRef: ActorRef) = Sync[F].delay { actorContext.unwatch(actorRef); () }
+      def unwatch(actorRef: ActorRef) = Sync[F].delay { val _ = actorContext.unwatch(actorRef) }
 
       def stop = Sync[F].delay(actorContext.stop(actorContext.self))
     }

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorOf.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorOf.scala
@@ -66,7 +66,7 @@ object ActorOf {
 
       override def postStop(): Unit = {
         act.value.postStop()
-        act.sync {
+        val _ = act.sync {
           actorVar.postStop().toFuture
         }
         super.postStop()

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorVar.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/ActorVar.scala
@@ -48,7 +48,7 @@ private[akkaeffect] object ActorVar {
     val serially = Serially[F, Option[State]](none)
 
     def update(f: Option[State] => F[Option[State]]): Unit = {
-      serially.apply { state =>
+      val _ = serially.apply { state =>
         val result = for {
           a <- f(state)
           _ <- a match {
@@ -64,7 +64,6 @@ private[akkaeffect] object ActorVar {
           } yield a
         }
       }.toFuture
-      ()
     }
 
     new ActorVar[F, A] {

--- a/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Terminated.scala
+++ b/actor/src/main/scala/com/evolutiongaming/akkaeffect/util/Terminated.scala
@@ -28,16 +28,14 @@ object Terminated {
             new Actor {
 
               override def preStart() = {
-                context.watch(actorRef)
-                ()
+                val _ = context.watch(actorRef)
               }
 
               def receive = {
                 case akka.actor.Terminated(`actorRef`) =>
-                  deferred
+                  val _ = deferred
                     .complete(())
                     .toFuture
-                  ()
               }
             }
 

--- a/build.sbt
+++ b/build.sbt
@@ -36,9 +36,6 @@ lazy val commonSettings = Seq(
       "-explain-types",
     ),
   ),
-  // `-Wnonunit-statement` (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
-  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
-  Test / scalacOptions -= "-Wnonunit-statement",
   // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
   // When a module's instrumented code runs inside another module's forked test JVM (before that
   // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,9 @@ lazy val commonSettings = Seq(
       "-explain-types",
     ),
   ),
+  // When sbt-scalac-opts-plugin enables `-Wnonunit-statement` it flags ScalaTest's
+  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
+  Test / scalacOptions -= "-Wnonunit-statement",
   // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
   // When a module's instrumented code runs inside another module's forked test JVM (before that
   // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,20 @@ lazy val commonSettings = Seq(
       "-explain-types",
     ),
   ),
+  // `-Wnonunit-statement` (added in sbt-scalac-opts-plugin 0.1.0) flags ScalaTest's
+  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
+  Test / scalacOptions -= "-Wnonunit-statement",
+  // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
+  // When a module's instrumented code runs inside another module's forked test JVM (before that
+  // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to
+  // the missing directory. Ensure it always exists after compile whenever coverage is enabled.
+  Compile / compile := Def.uncached {
+    val compiled = (Compile / compile).value
+    if (coverageEnabled.value) {
+      val _ = (crossTarget.value / "scoverage-data").mkdirs()
+    }
+    compiled
+  },
   publishTo              := Some(Resolver.evolutionReleases),
   versionPolicyIntention := Compatibility.BinaryCompatible, // sbt-version-policy
   versionScheme          := Some("semver-spec"),
@@ -48,7 +62,7 @@ lazy val commonSettings = Seq(
 )
 
 val alias =
-  addCommandAlias("build", "+all compile test") ++
+  addCommandAlias("build", "+all compile testFull") ++
     addCommandAlias("fmt", "+all scalafmtAll scalafmtSbt") ++
     // `check` is called with `+` in release workflow
     addCommandAlias("check", "all versionPolicyCheck Compile/doc scalafmtCheckAll scalafmtSbtCheck")

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import com.typesafe.tools.mima.core.{MissingClassProblem, ProblemFilters}
 lazy val commonSettings = Seq(
   organization         := "com.evolutiongaming",
   organizationName     := "Evolution",
-  organizationHomepage := Some(url("http://evolution.com")),
-  homepage             := Some(url("http://github.com/evolution-gaming/akka-effect")),
+  organizationHomepage := Some(uri("http://evolution.com")),
+  homepage             := Some(uri("http://github.com/evolution-gaming/akka-effect")),
   startYear            := Some(2019),
   crossScalaVersions   := Seq("2.13.18", "3.3.8"),
   scalaVersion         := crossScalaVersions.value.head,
@@ -36,9 +36,6 @@ lazy val commonSettings = Seq(
       "-explain-types",
     ),
   ),
-  // When sbt-scalac-opts-plugin enables `-Wnonunit-statement` it flags ScalaTest's
-  // `x shouldEqual y` used as a non-final statement; too noisy to fix across specs right now.
-  Test / scalacOptions -= "-Wnonunit-statement",
   // Under sbt 2 the compile cache can skip re-creating scoverage's data directory after `clean`.
   // When a module's instrumented code runs inside another module's forked test JVM (before that
   // module's own tests, if any, have run), scoverage.Invoker then crashes writing measurements to
@@ -55,17 +52,17 @@ lazy val commonSettings = Seq(
   versionScheme          := Some("semver-spec"),
   libraryDependencies ++= crossSettings(
     scalaVersion = scalaVersion.value,
-    if2 = Seq(compilerPlugin(`kind-projector` cross CrossVersion.full)),
+    if2 = Seq(compilerPlugin(`kind-projector`.cross(CrossVersion.full))),
     if3 = Nil,
   ),
-  licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
+  licenses := Seq(("MIT", uri("https://opensource.org/licenses/MIT"))),
 )
 
 val alias =
   addCommandAlias("build", "+all compile testFull") ++
-    addCommandAlias("fmt", "+all scalafmtAll scalafmtSbt") ++
+    addCommandAlias("fmt", "+all scalafmtRepo") ++
     // `check` is called with `+` in release workflow
-    addCommandAlias("check", "all versionPolicyCheck Compile/doc scalafmtCheckAll scalafmtSbtCheck")
+    addCommandAlias("check", "all versionPolicyCheck Compile/doc scalafmtCheckRepo")
 
 lazy val root = project
   .in(file("."))

--- a/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocal.scala
+++ b/cluster-sharding/src/main/scala/com/evolutiongaming/akkaeffect/cluster/sharding/ClusterShardingLocal.scala
@@ -140,7 +140,7 @@ object ClusterShardingLocal {
 
                 case RegionMsg.Rebalance =>
                   rebalancing = true
-                  context.system.scheduler.scheduleOnce(1.second, self, Unstash)
+                  val _ = context.system.scheduler.scheduleOnce(1.second, self, Unstash)
                   allocationStrategy
                     .rebalance(allocation(), Set.empty)
                     .onComplete { _ =>

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Append.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/Append.scala
@@ -108,8 +108,7 @@ object Append {
           }
 
           val onError: OnError[A] = { (error: Throwable, _: A, _: SeqNr) =>
-            fail(ref, error.pure[F]).toFuture
-            ()
+            val _ = fail(ref, error.pure[F]).toFuture
           }
         }
       }

--- a/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOf.scala
+++ b/persistence/src/main/scala/com/evolutiongaming/akkaeffect/persistence/PersistentActorOf.scala
@@ -144,7 +144,7 @@ object PersistentActorOf {
 
       override def postStop() = {
         val seqNr = lastSeqNr()
-        act.sync {
+        val _     = act.sync {
           val result = for {
             _ <- persistence.postStop(seqNr)
             _ <- release

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.14
+sbt.version=2.0.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.5
+sbt.version=2.0.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
-
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
+addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.1.0")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
-addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.1.0")
+addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.2.0")
 
 addSbtPlugin("com.evolution" % "sbt-artifactory-plugin" % "0.1.2")
 


### PR DESCRIPTION
Bumps sbt to 2.0.5 and sbt-scalac-opts-plugin to 0.1.0 (its first sbt 2 build).

sbt-coveralls has no sbt 2 release, so the upload moves to `coverallsapp/github-action`, following [smetrics](https://github.com/evolution-gaming/smetrics/blob/master/.github/workflows/ci.yml). `test` becomes `testFull`, and new `-Wnonunit-statement` warnings are fixed in main sources and disabled for tests.

The coverage build now runs before `check`: sbt 2 does not key its compile cache on scoverage instrumentation, so compiling first produced an empty report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tooling and continuous integration configuration.
  * Improved coverage reporting and automated quality checks.
  * Refreshed formatting and build commands for broader project consistency.
  * Updated project metadata and supported build configuration.

* **Refactor**
  * Clarified handling of ignored operation results across actor, cluster, and persistence components without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->