### PR TITLE
[AFTER 4.2.1!!!] revert versionPolicyIgnored for smetrics 3.0.0 (we do not use doobie module)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,8 +58,7 @@ lazy val commonSettings = Seq(
   licenses := Seq(("MIT", uri("https://opensource.org/licenses/MIT"))),
   versionPolicyIgnored ++= Seq(
     // add libraries here that are known to be binary compatible, like:
-    // TODO remove after next release, this project doesn't use doobie module
-    "com.evolutiongaming" %% "smetrics",
+//    "com.evolutiongaming" %% "smetrics",
   ),
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version policy configuration by removing an outdated exception and replacing its note with a commented example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->